### PR TITLE
[WIP][Http] Make http transport configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.4
   - 5.3
   - hhvm
- 
+
 matrix:
     allow_failures:
         - php: hhvm
@@ -13,17 +13,18 @@ matrix:
 before_script:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ~/xdebug.ini
   - curl http://cs.sensiolabs.org/get/php-cs-fixer.phar -o php-cs-fixer.phar
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev --no-interaction --prefer-source
+  - composer self-update
+  - if [[ "$TRAVIS_PHP_VERSION" = 5.3* ]]; then composer remove guzzlehttp/guzzle --dev --no-update; fi
+  - composer install --no-interaction --prefer-source
 
 script:
   - mkdir -p build/logs
   #- php -n php-cs-fixer.phar fix -v --dry-run --level=all src
   - output=$(php -n php-cs-fixer.phar fix -v --dry-run --level=all src); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
-  - php vendor/bin/phpcs --report=checkstyle --report-file=build/logs/checkstyle.xml --standard=build/config/phpcs.xml --ignore=*.html.php,*.config.php,*.twig.php src
-  - php vendor/bin/phpmd src xml build/config/phpmd.xml --reportfile build/logs/pmd.xml
+  - vendor/bin/phpcs --report=checkstyle --report-file=build/logs/checkstyle.xml --standard=build/config/phpcs.xml --ignore=*.html.php,*.config.php,*.twig.php src
+  - vendor/bin/phpmd src xml build/config/phpmd.xml --reportfile build/logs/pmd.xml
   - cp ~/xdebug.ini ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
-  - php vendor/bin/phpunit -c travis.phpunit.xml
+  - vendor/bin/phpunit -c travis.phpunit.xml
   - rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
 
 after_script:
@@ -35,4 +36,5 @@ after_script:
   - php travis/pmd.php
   - php travis/junit.php
   - php composer/bin/coveralls -v --exclude-no-stmt
+  - cat build/logs/coveralls-upload.json
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ php-coveralls
 [![Latest Stable Version](https://poser.pugx.org/satooshi/php-coveralls/v/stable.png)](https://packagist.org/packages/satooshi/php-coveralls)
 [![Total Downloads](https://poser.pugx.org/satooshi/php-coveralls/downloads.png)](https://packagist.org/packages/satooshi/php-coveralls)
 
-PHP client library for [Coveralls](https://coveralls.io). 
+PHP client library for [Coveralls](https://coveralls.io).
 
 # API doc
 
@@ -298,6 +298,12 @@ php vendor/bin/coveralls --help
 - `--verbose (-v)`: Used to show logs.
 - `--dry-run`: Used not to send json_file to Coveralls Jobs API.
 - `--exclude-no-stmt`: Used to exclude source files that have no executable statements.
+- `--http`: Used to configure the http transport. Default is `socket`
+
+## HTTP transport
+
+You can use different transport according to your own dependencies. By default, the `socket` one is used but you can
+use any available [here](https://github.com/egeloen/ivory-http-adapter/blob/master/doc/adapters.md#factory).
 
 ## .coveralls.yml
 
@@ -308,9 +314,10 @@ php-coveralls can use optional `.coveralls.yml` file to configure options. This 
 
 Following options can be used for php-coveralls.
 
-- `src_dir`: Used to specify where the root level of your source files directory is. Default is `src`. 
+- `src_dir`: Used to specify where the root level of your source files directory is. Default is `src`.
 - `coverage_clover`: Used to specify the path to `clover.xml`. Default is `build/logs/clover.xml`
 - `json_path`: Used to specify where to output `json_file` that will be uploaded to Coveralls API. Default is `build/logs/coveralls-upload.json`.
+- `http`: Used to configure the http transport. Default is `socket`.
 
 ```yml
 # .coveralls.yml example configuration
@@ -323,6 +330,7 @@ service_name: travis-pro # travis-ci or travis-pro
 src_dir: src
 coverage_clover: build/logs/clover.xml
 json_path: build/logs/coveralls-upload.json
+http: socket
 ```
 
 ### coverage clover configuration
@@ -340,7 +348,7 @@ coverage_clover: build/logs/clover-*.xml
 
 # array
 # specify files
-coverage_clover: 
+coverage_clover:
   - build/logs/clover-Auth.xml
   - build/logs/clover-Db.xml
   - build/logs/clover-Validator.xml

--- a/composer.json
+++ b/composer.json
@@ -17,23 +17,22 @@
         "php": ">=5.3",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/yaml": ">=2.0",
-        "symfony/console": ">=2.0",
-        "symfony/config": ">=2.0",
-        "symfony/stopwatch": ">=2.2",
-        "guzzle/guzzle": ">=2.7",
-        "psr/log": "1.0.0"
+        "symfony/yaml": "~2.0",
+        "symfony/console": "~2.0",
+        "symfony/config": "~2.0",
+        "symfony/stopwatch": "~2.2",
+        "egeloen/http-adapter": "~0.6.0@dev",
+        "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*@stable",
-        "phpunit/php-invoker": ">=1.1.0,<1.2.0",
-        "pdepend/pdepend": "dev-master as 2.0.0",
-        "phpmd/phpmd": "dev-master",
-        "sebastian/phpcpd": "1.4.*@stable",
-        "sebastian/finder-facade": "dev-master",
-        "theseer/fdomdocument": "dev-master",
-        "squizlabs/php_codesniffer": "1.4.*@stable",
-        "apigen/apigen": "2.8.*@stable"
+        "phpunit/phpunit": "~4.0",
+        "phpunit/php-invoker": "~1.1",
+        "phpmd/phpmd": "~2.0",
+        "sebastian/phpcpd": "~1.4",
+        "sebastian/finder-facade": "~1.1",
+        "theseer/fdomdocument": "~1.6",
+        "squizlabs/php_codesniffer": "~1.4",
+        "apigen/apigen": "~2.8"
     },
     "suggest": {
         "symfony/http-kernel": "Allows Symfony integration"

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/CoverallsApi.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/CoverallsApi.php
@@ -2,7 +2,7 @@
 namespace Satooshi\Bundle\CoverallsV1Bundle\Api;
 
 use Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration;
-use Guzzle\Http\Client;
+use Ivory\HttpAdapter\HttpAdapterInterface;
 
 /**
  * Coveralls API client.
@@ -21,17 +21,17 @@ abstract class CoverallsApi
     /**
      * HTTP client.
      *
-     * @var \Guzzle\Http\Client
+     * @var \Ivory\HttpAdapter\HttpAdapterInterface
      */
     protected $client;
 
     /**
      * Constructor.
      *
-     * @param Configuration       $config Configuration.
-     * @param \Guzzle\Http\Client $client HTTP client.
+     * @param Configuration                           $config Configuration.
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface $client HTTP client.
      */
-    public function __construct(Configuration $config, Client $client = null)
+    public function __construct(Configuration $config, HttpAdapterInterface $client = null)
     {
         $this->config = $config;
         $this->client = $client;
@@ -52,11 +52,11 @@ abstract class CoverallsApi
     /**
      * Set HTTP client.
      *
-     * @param \Guzzle\Http\Client $client HTTP client.
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface $client HTTP client.
      *
      * @return \Satooshi\Bundle\CoverallsV1Bundle\Api\CoverallsApi
      */
-    public function setHttpClient(Client $client)
+    public function setHttpClient(HttpAdapterInterface $client)
     {
         $this->client = $client;
 
@@ -66,7 +66,7 @@ abstract class CoverallsApi
     /**
      * Return HTTP client.
      *
-     * @return \Guzzle\Http\Client
+     * @return \Ivory\HttpAdapter\HttpAdapterInterface
      */
     public function getHttpClient()
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -123,7 +123,7 @@ class Jobs extends CoverallsApi
      *
      * @return \Guzzle\Http\Message\Response|null
      *
-     * @throws \RuntimeException
+     * @throws \Exception
      */
     public function send()
     {
@@ -145,15 +145,13 @@ class Jobs extends CoverallsApi
      * @param string $path     File path.
      * @param string $filename Filename.
      *
-     * @return \Guzzle\Http\Message\Response Response.
+     * @return \Psr\Http\Message\IncomingResponseInterface Response.
      *
-     * @throws \RuntimeException
+     * @throws \Exception
      */
     protected function upload($url, $path, $filename)
     {
-        $request  = $this->client->post($url)->addPostFiles(array($filename => $path));
-
-        return $request->send();
+        return $this->client->post($url, array(), array(), array($filename => $path));
     }
 
     // accessor

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
@@ -4,9 +4,9 @@ namespace Satooshi\Bundle\CoverallsV1Bundle\Command;
 use Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs;
 use Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration;
 use Satooshi\Bundle\CoverallsV1Bundle\Config\Configurator;
+use Satooshi\Bundle\CoverallsV1Bundle\Http\ClientFactory;
 use Satooshi\Bundle\CoverallsV1Bundle\Repository\JobsRepository;
 use Satooshi\Component\Log\ConsoleLogger;
-use Guzzle\Http\Client;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -65,6 +65,12 @@ class CoverallsV1JobsCommand extends Command
             null,
             InputOption::VALUE_NONE,
             'Exclude source files that have no executable statements'
+        )
+        ->addOption(
+            'http',
+            null,
+            InputOption::VALUE_NONE,
+            'HTTP client name'
         )
         ->addOption(
             'env',
@@ -132,7 +138,7 @@ class CoverallsV1JobsCommand extends Command
      */
     protected function executeApi(Configuration $config)
     {
-        $client     = new Client();
+        $client     = ClientFactory::create($config->getHttp());
         $api        = new Jobs($config, $client);
         $repository = new JobsRepository($api, $config);
 

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configuration.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configuration.php
@@ -71,6 +71,13 @@ class Configuration
     protected $excludeNoStatements = false;
 
     /**
+     * The http client name.
+     *
+     * @var string
+     */
+    protected $http = 'socket';
+
+    /**
      * Whether to show log.
      *
      * @var boolean
@@ -314,6 +321,32 @@ class Configuration
     public function isExcludeNoStatements()
     {
         return $this->excludeNoStatements;
+    }
+
+    /**
+     * Set the http client name.
+     *
+     * @param string $http
+     *
+     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     */
+    public function setHttp($http)
+    {
+        if ($http) {
+            $this->http = trim($http);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Return the http client name.
+     *
+     * @return string
+     */
+    public function getHttp()
+    {
+        return $this->http;
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -97,7 +97,8 @@ class Configurator
         ->setRootDir($rootDir)
         ->setCloverXmlPaths($this->ensureCloverXmlPaths($options['coverage_clover'], $rootDir, $file))
         ->setJsonPath($this->ensureJsonPath($options['json_path'], $rootDir, $file))
-        ->setExcludeNoStatements($options['exclude_no_stmt']);
+        ->setExcludeNoStatements($options['exclude_no_stmt'])
+        ->setHttp($options['http']);
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/CoverallsConfiguration.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/CoverallsConfiguration.php
@@ -61,6 +61,9 @@ class CoverallsConfiguration implements ConfigurationInterface
                 ->booleanNode('exclude_no_stmt')
                     ->defaultFalse()
                 ->end()
+                ->scalarNode('http')
+                    ->defaultValue('socket')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Http/ClientFactory.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Http/ClientFactory.php
@@ -1,0 +1,22 @@
+<?php
+namespace Satooshi\Bundle\CoverallsV1Bundle\Http;
+
+use Ivory\HttpAdapter\Event\Subscriber\StatusCodeSubscriber;
+use Ivory\HttpAdapter\HttpAdapterFactory;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class ClientFactory extends HttpAdapterFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function create($name)
+    {
+        $client = parent::create($name);
+        $client->getConfiguration()->getEventDispatcher()->addSubscriber(new StatusCodeSubscriber());
+
+        return $client;
+    }
+}

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
@@ -70,39 +70,29 @@ class JobsTest extends ProjectTestCase
 
     protected function createAdapterMockNeverCalled()
     {
-        $client = $this->getMock('Guzzle\Http\Client', array('send'));
+        $client = $this->getMock('Ivory\HttpAdapter\HttpAdapterInterface');
 
         $client
         ->expects($this->never())
-        ->method('send');
+        ->method('post');
 
         return $client;
     }
 
     protected function createAdapterMockWith($url, $filename, $jsonPath)
     {
-        $client = $this->getMock('Guzzle\Http\Client', array('post', 'addPostFiles'));
-        $request = $this->getMockBuilder('Guzzle\Http\Message\EntityEnclosingRequest')
-        ->disableOriginalConstructor()
-        ->getMock();
+        $client = $this->getMock('Ivory\HttpAdapter\HttpAdapterInterface');
 
         $client
         ->expects($this->once())
         ->method('post')
-        ->with($this->equalTo($url))
+        ->with(
+            $this->equalTo($url),
+            $this->equalTo(array()),
+            $this->equalTo(array()),
+            $this->equalTo(array($filename => $jsonPath))
+        )
         ->will($this->returnSelf());
-
-        $client
-        ->expects($this->once())
-        ->method('addPostFiles')
-        ->with($this->equalTo(array($filename => $jsonPath)))
-        ->will($this->returnValue($request));
-
-        $request
-        ->expects($this->once())
-        ->method('send')
-        ->with()
-        ;
 
         return $client;
     }

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommandTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommandTest.php
@@ -86,6 +86,7 @@ XML;
                 '--dry-run' => true,
                 '--config'  => 'coveralls.yml',
                 '--env'     => 'test',
+                '--http'    => 'socket',
             )
         );
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfigurationTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfigurationTest.php
@@ -87,6 +87,16 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->object->isExcludeNoStatements());
     }
 
+    // getHttp()
+
+    /**
+     * @test
+     */
+    public function shouldHaveSocketHttpOnConstruction()
+    {
+        $this->assertSame('socket', $this->object->getHttp());
+    }
+
     // isVerbose
 
     /**
@@ -360,6 +370,21 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($same, $this->object);
         $this->assertTrue($this->object->isExcludeNoStatements());
+    }
+
+    // setHttp()
+
+    /**
+     * @test
+     */
+    public function shouldSetHttp()
+    {
+        $expected = 'socket';
+
+        $same = $this->object->setHttp($expected);
+
+        $this->assertSame($same, $this->object);
+        $this->assertSame($expected, $this->object->getHttp());
     }
 
     // setVerbose()

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
@@ -35,12 +35,13 @@ class ConfiguratorTest extends ProjectTestCase
 
     // custom assertion
 
-    protected function assertConfiguration(Configuration $config, $srcDir, array $cloverXml, $jsonPath, $excludeNoStatements = false)
+    protected function assertConfiguration(Configuration $config, $srcDir, array $cloverXml, $jsonPath, $excludeNoStatements = false, $http = 'socket')
     {
         $this->assertEquals($srcDir, $config->getSrcDir());
         $this->assertEquals($cloverXml, $config->getCloverXmlPaths());
         $this->assertEquals($jsonPath, $config->getJsonPath());
         $this->assertEquals($excludeNoStatements, $config->isExcludeNoStatements());
+        $this->assertEquals($http, $config->getHttp());
     }
 
     // load()
@@ -231,6 +232,20 @@ class ConfiguratorTest extends ProjectTestCase
         $config = $this->object->load($path, $this->rootDir);
 
         $this->assertConfiguration($config, $this->srcDir, array($this->cloverXmlPath), $this->jsonPath, false);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldLoadHttp()
+    {
+        $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
+
+        $path = realpath(__DIR__ . '/yaml/http.yml');
+
+        $config = $this->object->load($path, $this->rootDir);
+
+        $this->assertConfiguration($config, $this->srcDir, array($this->cloverXmlPath), $this->jsonPath, false, 'socket');
     }
 
     // configured src_dir not found

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/yaml/http.yml
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/yaml/http.yml
@@ -1,0 +1,1 @@
+http: socket

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFileTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFileTest.php
@@ -634,6 +634,29 @@ XML;
     /**
      * @test
      */
+    public function shouldFillJobsForRepoToken()
+    {
+        $repoToken   = 'token';
+        $serviceName = 'travis-pro';
+
+        $env = array();
+        $env['COVERALLS_REPO_TOKEN']  = $repoToken;
+        $env['COVERALLS_RUN_LOCALLY'] = '1';
+        $env['CI_NAME']               = $serviceName;
+
+        $object = $this->collectJsonFile();
+
+        $same = $object->fillJobs($env);
+
+        $this->assertSame($same, $object);
+        $this->assertEquals($repoToken, $object->getRepoToken());
+        $this->assertEquals($serviceName, $object->getServiceName());
+        $this->assertNull($object->getServiceJobId());
+    }
+
+    /**
+     * @test
+     */
     public function shouldFillJobsForUnsupportedJob()
     {
         $repoToken = 'token';

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Http/ClientFactoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Http/ClientFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace Satooshi\Bundle\CoverallsV1Bundle\Http;
+
+use Ivory\HttpAdapter\Event\Events;
+use Satooshi\Bundle\CoverallsV1Bundle\Http\ClientFactory;
+
+class ClientFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldCreateClientSubscriber()
+    {
+        $client = ClientFactory::create(ClientFactory::SOCKET);
+
+        $listeners = $client->getConfiguration()->getEventDispatcher()->getListeners();
+
+        $this->assertCount(1, $listeners);
+        $this->assertArrayHasKey(Events::POST_SEND, $listeners);
+
+        $listener = $listeners[Events::POST_SEND];
+
+        $this->assertCount(1, $listener);
+        $this->assertArrayHasKey(0, $listener);
+        $this->assertArrayHasKey(0, $listener[0]);
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\Subscriber\StatusCodeSubscriber', $listener[0][0]);
+    }
+}

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -1,10 +1,7 @@
 <?php
 namespace Satooshi\Bundle\CoverallsV1Bundle\Repository;
 
-use Guzzle\Common\Exception\RuntimeException;
-use Guzzle\Http\Exception\ClientErrorResponseException;
-use Guzzle\Http\Exception\CurlException;
-use Psr\Log\NullLogger;
+use Ivory\HttpAdapter\HttpAdapterException;
 use Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration;
 use Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile;
 use Satooshi\Bundle\CoverallsV1Bundle\Entity\Metrics;
@@ -175,14 +172,11 @@ class JobsRepositoryTest extends ProjectTestCase
             ->with()
             ->will($this->returnValue($response));
         } else {
-            if ($statusCode === null) {
-                $exception = new \Guzzle\Http\Exception\CurlException();
-            } elseif ($statusCode === 422) {
-                $exception = new \Guzzle\Http\Exception\ClientErrorResponseException();
+            if ($response !== null) {
+                $exception = new HttpAdapterException();
                 $exception->setResponse($response);
             } else {
-                $exception = new \Guzzle\Http\Exception\ServerErrorResponseException();
-                $exception->setResponse($response);
+                $exception = new \Exception();
             }
 
             $api
@@ -198,37 +192,25 @@ class JobsRepositoryTest extends ProjectTestCase
     protected function createResponseMock($statusCode, $reasonPhrase, $body)
     {
         $json     = is_array($body) ? json_encode($body) : $body;
-        $args     = array($statusCode, null, $json);
-        $methods  = array('getStatusCode', 'getReasonPhrase', 'json');
-        $response = $this->getMock('Guzzle\Http\Message\Response', $methods, $args);
+        $response = $this->getMock('Psr\Http\Message\IncomingResponseInterface');
 
         $response
-        ->expects($this->once())
+        ->expects($this->any())
         ->method('getStatusCode')
         ->with()
         ->will($this->returnValue($statusCode));
 
         $response
-        ->expects($this->once())
+        ->expects($this->any())
         ->method('getReasonPhrase')
         ->with()
         ->will($this->returnValue($reasonPhrase));
 
-        if (is_array($body)) {
-            $response
-            ->expects($this->once())
-            ->method('json')
-            ->with()
-            ->will($this->returnValue($body));
-        } else {
-            $exception = new \Guzzle\Common\Exception\RuntimeException();
-
-            $response
-            ->expects($this->once())
-            ->method('json')
-            ->with()
-            ->will($this->throwException($exception));
-        }
+        $response
+        ->expects($this->any())
+        ->method('getBody')
+        ->with()
+        ->will($this->returnValue($json));
 
         return $response;
     }
@@ -367,7 +349,7 @@ class JobsRepositoryTest extends ProjectTestCase
         $object->persist();
     }
 
-    // curl error
+    // error
 
     /**
      * @test
@@ -384,16 +366,15 @@ class JobsRepositoryTest extends ProjectTestCase
         $object->persist();
     }
 
-    // response 422
+    // http error
 
     /**
      * @test
      */
-    public function response422()
+    public function responseError()
     {
         $statusCode = 422;
-        $json       = array('message' => 'Build processing error.', 'url' => '', 'error' => true);
-        $response   = $this->createResponseMock($statusCode, 'Unprocessable Entity', $json);
+        $response   = $this->createResponseMock($statusCode, 'Unprocessable Entity', null);
         $api        = $this->createApiMock($response, $statusCode);
         $config     = $this->createConfiguration();
         $logger     = $this->createLoggerMock();
@@ -404,15 +385,15 @@ class JobsRepositoryTest extends ProjectTestCase
         $object->persist();
     }
 
-    // response 500
+    // json error
 
     /**
      * @test
      */
-    public function response500()
+    public function jsonError()
     {
         $statusCode = 500;
-        $response   = $this->createResponseMock($statusCode, 'Internal Server Error', 'response');
+        $response   = $this->createResponseMock($statusCode, 'Error', '{"error":"foo","message":"bar"}');
         $api        = $this->createApiMock($response, $statusCode);
         $config     = $this->createConfiguration();
         $logger     = $this->createLoggerMock();


### PR DESCRIPTION
This PR is a fixed version of #73 which now relies on the last `psr/http-message` spec. I still need to investigate a strange behavior (work locally but seems not working with travis...), so, don't merge this PR right now :). 

Furthermore, I'm not sure about the composer constraint for `egeloen/http-adapter`. As we are in pre `1.0.0` release, I break BC in minor versions making potentially the `0.5` not compatible with the `0.6` versions so, I have decided to fix the constraint to the `0.5.*` releases and then, if it is compatible we can bump the constraint on the next release. What do you think?