### PR TITLE
[Composer] Update to PSR-4 + Use Semver constraint + Remove minimum-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "homepage": "https://github.com/satooshi/php-coveralls",
     "type": "library",
     "license": "MIT",
-    "minimum-stability": "stable",
     "authors": [
         {
             "name": "Kitamura Satoshi",
@@ -17,29 +16,31 @@
         "php": ">=5.3",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/yaml": ">=2.0",
-        "symfony/console": ">=2.0",
-        "symfony/config": ">=2.0",
-        "symfony/stopwatch": ">=2.2",
-        "guzzle/guzzle": ">=2.7",
-        "psr/log": "1.0.0"
+        "symfony/yaml": "~2.0",
+        "symfony/console": "~2.0",
+        "symfony/config": "~2.0",
+        "symfony/stopwatch": "~2.2",
+        "guzzle/guzzle": "~2.7|~3.0",
+        "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*@stable",
-        "phpunit/php-invoker": ">=1.1.0,<1.2.0",
-        "pdepend/pdepend": "dev-master as 2.0.0",
-        "phpmd/phpmd": "dev-master",
-        "sebastian/phpcpd": "1.4.*@stable",
-        "sebastian/finder-facade": "dev-master",
-        "theseer/fdomdocument": "dev-master",
-        "squizlabs/php_codesniffer": "1.4.*@stable",
-        "apigen/apigen": "2.8.*@stable"
+        "phpunit/phpunit": "~4.0",
+        "phpunit/php-invoker": "~1.1",
+        "phpmd/phpmd": "~2.0",
+        "sebastian/phpcpd": "~1.4",
+        "sebastian/finder-facade": "~1.1",
+        "theseer/fdomdocument": "~1.6",
+        "squizlabs/php_codesniffer": "~1.4",
+        "apigen/apigen": "~2.8"
     },
     "suggest": {
         "symfony/http-kernel": "Allows Symfony integration"
     },
     "autoload": {
-        "psr-0": { "Satooshi\\Component": "src/", "Satooshi\\Bundle": "src/" }
+        "psr-4": { "Satooshi\\": "src/Satooshi/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Satooshi\\": "tests/Satooshi/" }
     },
     "bin": ["composer/bin/coveralls"],
     "extra": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="tests/bootstrap.php">
+         bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="PHP Coveralls component test suite">
             <directory>./tests/</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-
-$loader = require realpath(__DIR__ . '/../vendor/autoload.php');
-$loader->add('Satooshi', __DIR__);

--- a/travis.phpunit.xml
+++ b/travis.phpunit.xml
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="tests/bootstrap.php">
+         bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="PHP Coveralls component test suite">
             <directory>./tests/</directory>


### PR DESCRIPTION
As explain in the title, this PR does three things:

 * Remove the `minimum-stability` flag as `stable` is the default one.
 * Upgrade all constraints to ones following Semver and so, should not break BC
 * Upgrade tha autoloading to PSR-4

I need this PR meanwhile we find the issues in #75 (One of my travis-ci build can't be resolved. See [here](https://travis-ci.org/egeloen/IvoryCKEditorBundle/jobs/40826801)).