### PR TITLE
Fix Yaml::parse deprecation

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -50,7 +50,7 @@ class Configurator
         $path = realpath($coverallsYmlPath);
 
         if ($file->isRealFileReadable($path)) {
-            $yml = Yaml::parse($path);
+            $yml = Yaml::parse(file_get_contents($path));
 
             return empty($yml) ? array() : $yml;
         }


### PR DESCRIPTION
The `parse` method will not support filenames anymore in a further Yaml version. [See here](https://github.com/symfony/Yaml/blob/2.7/Yaml.php#L49) for more info.