### PR TITLE
Configured composer to use symfony/yaml version 2.1 (Yaml::parse was deprecated on 2.2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/yaml": ">=2.0",
+        "symfony/yaml": "2.1",
         "symfony/console": ">=2.0",
         "symfony/config": ">=2.0",
         "symfony/stopwatch": ">=2.2",


### PR DESCRIPTION
Dear Kitamura:

First of all, thank you very much for your great work on php-coveralls. We used php-coveralls a lot and is really useful. However, recently we begin facing a problem while running our tests:

![coveralls-yaml-error](https://cloud.githubusercontent.com/assets/865865/7487163/3b87a6e8-f388-11e4-8989-69df23418a43.png)

We fixed this problem just requiring on composer the use of symfony/yaml version 2.1 (but not higher) and it solves this issue.

Could be possible merge this pull request on your repo? We prefer use satooshi/php-coveralls instead of mantain a fork, and this change could be useful for other users too.

Thank you very much.

Best Regards,
Leandro