### PR TITLE
Update configurator to use the Yaml `Parser` class

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -4,7 +4,7 @@ namespace Satooshi\Bundle\CoverallsV1Bundle\Config;
 use Satooshi\Component\File\Path;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Parser;
 
 /**
  * Coveralls API configurator.
@@ -50,7 +50,8 @@ class Configurator
         $path = realpath($coverallsYmlPath);
 
         if ($file->isRealFileReadable($path)) {
-            $yml = Yaml::parse($path);
+            $parser = new Parser();
+            $yml = $parser->parse(file_get_contents($path));;
 
             return empty($yml) ? array() : $yml;
         }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -51,7 +51,7 @@ class Configurator
 
         if ($file->isRealFileReadable($path)) {
             $parser = new Parser();
-            $yml = $parser->parse(file_get_contents($path));;
+            $yml = $parser->parse(file_get_contents($path));
 
             return empty($yml) ? array() : $yml;
         }


### PR DESCRIPTION
Closes #93 Update configurator to use the Yaml `Parser` class instead of the static method `Yaml::parse` which is deprecated.