### PR TITLE
Yaml parser

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -52,7 +52,7 @@ class Configurator
 
         if ($file->isRealFileReadable($path)) {
             $parser = new Parser();
-            $yml = $parser->parse(file_get_contents($path));;
+            $yml = $parser->parse(file_get_contents($path));
 
             return empty($yml) ? array() : $yml;
         }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -5,7 +5,7 @@ namespace Satooshi\Bundle\CoverallsV1Bundle\Config;
 use Satooshi\Component\File\Path;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Parser;
 
 /**
  * Coveralls API configurator.
@@ -51,7 +51,8 @@ class Configurator
         $path = realpath($coverallsYmlPath);
 
         if ($file->isRealFileReadable($path)) {
-            $yml = Yaml::parse($path);
+            $parser = new Parser();
+            $yml = $parser->parse(file_get_contents($path));;
 
             return empty($yml) ? array() : $yml;
         }


### PR DESCRIPTION
Closes #93. Update configurator to use the Yaml `Parser` class. This replaces #94.

Dependencies are currently broken and this PR requires #76.