### PR TITLE
Fix git branch for travis ci

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollector.php
@@ -57,6 +57,10 @@ class GitInfoCollector
      */
     protected function collectBranch()
     {
+        if(isset($_SERVER['TRAVIS_BRANCH'])){
+            return $_SERVER['TRAVIS_BRANCH'];
+        }
+        
         $branchesResult = $this->command->getBranches();
 
         foreach ($branchesResult as $result) {


### PR DESCRIPTION
Travis runs in a detached head state which will cause the branch in coveralls to look like `(detached abf2510a)`. To fix this we look for the existence of the `TRAVIS_BRANCH` environment variable and return that if it exists.