### PR TITLE
Update YAML dependency and fix deprecated method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "symfony/yaml": ">=2.0",
+        "symfony/yaml": "~2.8",
         "symfony/console": ">=2.0",
         "symfony/config": ">=2.0",
         "symfony/stopwatch": ">=2.2",

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -50,7 +50,7 @@ class Configurator
         $path = realpath($coverallsYmlPath);
 
         if ($file->isRealFileReadable($path)) {
-            $yml = Yaml::parse($path);
+            $yml = Yaml::parse(file_get_contents($path));
 
             return empty($yml) ? array() : $yml;
         }


### PR DESCRIPTION
Many other packages are now requiring newer versions of YAML. The ability to pass a file name into `YAML::parse` is completely removed in the newest versions, and causes this to break. This is the minimal change needed to make it work again.

cc: @satooshi 

Fixes #93