### PR TITLE
Make relative path check Windows compatible

### DIFF
--- a/src/Satooshi/Component/File/Path.php
+++ b/src/Satooshi/Component/File/Path.php
@@ -18,7 +18,15 @@ class Path
      */
     public function isRelativePath($path)
     {
-        return strlen($path) === 0 || strpos($path, DIRECTORY_SEPARATOR) !== 0;
+        if (strlen($path) === 0) {
+            return true;
+        }
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            return !preg_match('/^[a-z]+\:\\\\/i', $path);
+        } else {
+            return strpos($path, DIRECTORY_SEPARATOR) !== 0;
+        }
     }
 
     /**


### PR DESCRIPTION
Currently the check for relative paths only works for non-Windows platforms, as an absolute Windows path would never start with `DIRECTORY_SEPARATOR`.