### PR TITLE
Upgrade to PHP 5.5 and Guzzle 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: php
 
 matrix:
     include:
-        - php: 5.3.3
-          env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-        - php: 5.3
-          env: 'BOX=yes'
-        - php: 5.4
         - php: 5.5
+          env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+        - php: 5.5
+          env: 'BOX=yes'
         - php: 5.6
         - php: 7.0
           env: CHECKS=yes

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   timezone: America/Los_Angeles
   php:
-    version: 5.3.3
+    version: 5.5.0
 
 dependencies:
   override:

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "guzzle/guzzle": "^2.8|^3.0",
+        "guzzlehttp/guzzle": "^6.0",
         "psr/log": "^1.0",
         "symfony/config": "^2.4|^3.0",
         "symfony/console": "^2.1|^3.0",

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/CoverallsApi.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/CoverallsApi.php
@@ -3,7 +3,7 @@
 namespace Satooshi\Bundle\CoverallsV1Bundle\Api;
 
 use Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration;
-use Guzzle\Http\Client;
+use GuzzleHttp\Client;
 
 /**
  * Coveralls API client.
@@ -22,15 +22,15 @@ abstract class CoverallsApi
     /**
      * HTTP client.
      *
-     * @var \Guzzle\Http\Client
+     * @var \GuzzleHttp\Client
      */
     protected $client;
 
     /**
      * Constructor.
      *
-     * @param Configuration       $config Configuration.
-     * @param \Guzzle\Http\Client $client HTTP client.
+     * @param Configuration      $config Configuration.
+     * @param \GuzzleHttp\Client $client HTTP client.
      */
     public function __construct(Configuration $config, Client $client = null)
     {
@@ -53,7 +53,7 @@ abstract class CoverallsApi
     /**
      * Set HTTP client.
      *
-     * @param \Guzzle\Http\Client $client HTTP client.
+     * @param \GuzzleHttp\Client $client HTTP client.
      *
      * @return \Satooshi\Bundle\CoverallsV1Bundle\Api\CoverallsApi
      */
@@ -67,7 +67,7 @@ abstract class CoverallsApi
     /**
      * Return HTTP client.
      *
-     * @return \Guzzle\Http\Client
+     * @return \GuzzleHttp\Client
      */
     public function getHttpClient()
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -122,9 +122,7 @@ class Jobs extends CoverallsApi
     /**
      * Send json_file to jobs API.
      *
-     * @return \Guzzle\Http\Message\Response|null
-     *
-     * @throws \RuntimeException
+     * @return \GuzzleHttp\Psr7\Response|null
      */
     public function send()
     {
@@ -146,15 +144,20 @@ class Jobs extends CoverallsApi
      * @param string $path     File path.
      * @param string $filename Filename.
      *
-     * @return \Guzzle\Http\Message\Response Response.
-     *
-     * @throws \RuntimeException
+     * @return \GuzzleHttp\Psr7\Response
      */
     protected function upload($url, $path, $filename)
     {
-        $request  = $this->client->post($url)->addPostFiles(array($filename => $path));
+        $options = [
+            'multipart' => [
+                [
+                    'name' => $filename,
+                    'contents' => fopen($path, 'r'),
+                ],
+            ],
+        ];
 
-        return $request->send();
+        return $this->client->post($url, $options);
     }
 
     // accessor

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
@@ -8,7 +8,7 @@ use Satooshi\Bundle\CoverallsV1Bundle\Config\Configurator;
 use Satooshi\Bundle\CoverallsV1Bundle\Repository\JobsRepository;
 use Satooshi\Component\Log\ConsoleLogger;
 use Satooshi\Component\File\Path;
-use Guzzle\Http\Client;
+use GuzzleHttp\Client;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
@@ -2,8 +2,8 @@
 
 namespace Satooshi\Bundle\CoverallsV1Bundle\Repository;
 
-use Guzzle\Http\Client;
-use Guzzle\Http\Message\Response;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs;
@@ -164,14 +164,14 @@ class JobsRepository implements LoggerAwareInterface
             }
 
             return;
-        } catch (\Guzzle\Http\Exception\CurlException $e) {
+        } catch (\GuzzleHttp\Exception\ConnectException $e) {
             // connection error
             $message  = sprintf("Connection error occurred. %s\n\n%s", $e->getMessage(), $e->getTraceAsString());
-        } catch (\Guzzle\Http\Exception\ClientErrorResponseException $e) {
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
             // 422 Unprocessable Entity
             $response = $e->getResponse();
             $message  = sprintf('Client error occurred. status: %s %s', $response->getStatusCode(), $response->getReasonPhrase());
-        } catch (\Guzzle\Http\Exception\ServerErrorResponseException $e) {
+        } catch (\GuzzleHttp\Exception\ServerException $e) {
             // 500 Internal Server Error
             // 503 Service Unavailable
             $response = $e->getResponse();
@@ -244,7 +244,7 @@ class JobsRepository implements LoggerAwareInterface
      */
     protected function logResponse(Response $response)
     {
-        $raw_body = $response->getBody(true);
+        $raw_body = (string) $response->getBody();
         $body = json_decode($raw_body, true);
         if ($body === null) {
             // the response body is not in JSON format


### PR DESCRIPTION
Brings Coveralls more in line with modern code bases that are using
PSR-7 and newer versions of Guzzle.

Also changes the minimum PHP version to 5.5 and upgrades packages.

Fixes #80
Refs #152

**Note:** I have not tested this beyond what the continuous integration tests do. I assume they are complete enough to cover the changes made.