### PR TITLE
let output json path be configurable

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
@@ -83,6 +83,13 @@ class CoverallsV1JobsCommand extends Command
             array()
         )
         ->addOption(
+            'json_path',
+            '-o',
+            InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            'Coveralls output json file',
+            array()
+        )
+        ->addOption(
             'root_dir',
             '-r',
             InputOption::VALUE_OPTIONAL,

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -93,6 +93,8 @@ class Configurator
 
         $repoToken       = $options['repo_token'];
         $repoSecretToken = $options['repo_secret_token'];
+
+        // handle coverage clover
         if ($input !== null
             && $input->hasOption('coverage_clover')
             && count($input->getOption('coverage_clover')) > 0) {
@@ -101,12 +103,21 @@ class Configurator
             $coverage_clover = $options['coverage_clover'];
         }
 
+        // handle output json path
+        if ($input !== null
+            && $input->hasOption('json_path')
+            && count($input->getOption('json_path')) > 0) {
+            $json_path = $input->getOption('json_path')[0];
+        } else {
+            $json_path = $options['json_path'];
+        }
+
         return $configuration
         ->setRepoToken($repoToken !== null ? $repoToken : $repoSecretToken)
         ->setServiceName($options['service_name'])
         ->setRootDir($rootDir)
         ->setCloverXmlPaths($this->ensureCloverXmlPaths($coverage_clover, $rootDir, $file))
-        ->setJsonPath($this->ensureJsonPath($options['json_path'], $rootDir, $file))
+        ->setJsonPath($this->ensureJsonPath($json_path, $rootDir, $file))
         ->setExcludeNoStatements($options['exclude_no_stmt']);
     }
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
@@ -17,11 +17,11 @@ class ConfiguratorTest extends ProjectTestCase
 {
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../../..');
+        $this->projectDir = realpath(__DIR__.'/../../../..');
 
         $this->setUpDir($this->projectDir);
 
-        $this->srcDir = $this->rootDir . '/src';
+        $this->srcDir = $this->rootDir.'/src';
 
         $this->object = new Configurator();
     }
@@ -55,7 +55,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/dummy.yml');
+        $path = realpath(__DIR__.'/yaml/dummy.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -71,7 +71,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir(null, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/dummy.yml');
+        $path = realpath(__DIR__.'/yaml/dummy.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -86,7 +86,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, null);
 
-        $path = realpath(__DIR__ . '/yaml/dummy.yml');
+        $path = realpath(__DIR__.'/yaml/dummy.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -101,7 +101,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath, true);
 
-        $path = realpath(__DIR__ . '/yaml/dummy.yml');
+        $path = realpath(__DIR__.'/yaml/dummy.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -114,7 +114,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath, false, true);
 
-        $path = realpath(__DIR__ . '/yaml/dummy.yml');
+        $path = realpath(__DIR__.'/yaml/dummy.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -128,7 +128,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/empty.yml');
+        $path = realpath(__DIR__.'/yaml/empty.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -145,7 +145,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/src_dir.yml');
+        $path = realpath(__DIR__.'/yaml/src_dir.yml');
 
         $config = $this->object->load($path, $this->rootDir);
     }
@@ -157,7 +157,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/coverage_clover.yml');
+        $path = realpath(__DIR__.'/yaml/coverage_clover.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -171,7 +171,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, array($this->cloverXmlPath1, $this->cloverXmlPath2));
 
-        $path = realpath(__DIR__ . '/yaml/coverage_clover.yml');
+        $path = realpath(__DIR__.'/yaml/coverage_clover.yml');
 
         // Mocking command line options.
         $defs = new InputDefinition(
@@ -201,7 +201,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, array($this->cloverXmlPath1, $this->cloverXmlPath2));
 
-        $path = realpath(__DIR__ . '/yaml/coverage_clover_glob.yml');
+        $path = realpath(__DIR__.'/yaml/coverage_clover_glob.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -215,7 +215,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, array($this->cloverXmlPath1, $this->cloverXmlPath2));
 
-        $path = realpath(__DIR__ . '/yaml/coverage_clover_array.yml');
+        $path = realpath(__DIR__.'/yaml/coverage_clover_array.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -229,7 +229,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/json_path.yml');
+        $path = realpath(__DIR__.'/yaml/json_path.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -243,7 +243,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/json_path.yml');
+        $path = realpath(__DIR__.'/yaml/json_path.yml');
 
         // Mocking command line options.
         $defs = new InputDefinition(
@@ -257,7 +257,7 @@ class ConfiguratorTest extends ProjectTestCase
         );
         $inputArray = array(
             '--json_path' => array(
-                'build/logs/coveralls-upload.json'
+                'build/logs/coveralls-upload.json',
             ),
         );
         $input = new ArrayInput($inputArray, $defs);
@@ -272,7 +272,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/exclude_no_stmt_true.yml');
+        $path = realpath(__DIR__.'/yaml/exclude_no_stmt_true.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -286,7 +286,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/exclude_no_stmt_false.yml');
+        $path = realpath(__DIR__.'/yaml/exclude_no_stmt_false.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -303,7 +303,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/coverage_clover_not_found.yml');
+        $path = realpath(__DIR__.'/yaml/coverage_clover_not_found.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -316,7 +316,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/coverage_clover_invalid.yml');
+        $path = realpath(__DIR__.'/yaml/coverage_clover_invalid.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -331,7 +331,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/json_path_not_found.yml');
+        $path = realpath(__DIR__.'/yaml/json_path_not_found.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -346,7 +346,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__ . '/yaml/exclude_no_stmt_invalid.yml');
+        $path = realpath(__DIR__.'/yaml/exclude_no_stmt_invalid.yml');
 
         $this->object->load($path, $this->rootDir);
     }

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
@@ -17,11 +17,11 @@ class ConfiguratorTest extends ProjectTestCase
 {
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__.'/../../../..');
+        $this->projectDir = realpath(__DIR__ . '/../../../..');
 
         $this->setUpDir($this->projectDir);
 
-        $this->srcDir = $this->rootDir.'/src';
+        $this->srcDir = $this->rootDir . '/src';
 
         $this->object = new Configurator();
     }
@@ -55,7 +55,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/dummy.yml');
+        $path = realpath(__DIR__ . '/yaml/dummy.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -71,7 +71,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir(null, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/dummy.yml');
+        $path = realpath(__DIR__ . '/yaml/dummy.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -86,7 +86,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, null);
 
-        $path = realpath(__DIR__.'/yaml/dummy.yml');
+        $path = realpath(__DIR__ . '/yaml/dummy.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -101,7 +101,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath, true);
 
-        $path = realpath(__DIR__.'/yaml/dummy.yml');
+        $path = realpath(__DIR__ . '/yaml/dummy.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -114,7 +114,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath, false, true);
 
-        $path = realpath(__DIR__.'/yaml/dummy.yml');
+        $path = realpath(__DIR__ . '/yaml/dummy.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -128,7 +128,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/empty.yml');
+        $path = realpath(__DIR__ . '/yaml/empty.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -145,7 +145,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/src_dir.yml');
+        $path = realpath(__DIR__ . '/yaml/src_dir.yml');
 
         $config = $this->object->load($path, $this->rootDir);
     }
@@ -157,7 +157,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/coverage_clover.yml');
+        $path = realpath(__DIR__ . '/yaml/coverage_clover.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -171,7 +171,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, array($this->cloverXmlPath1, $this->cloverXmlPath2));
 
-        $path = realpath(__DIR__.'/yaml/coverage_clover.yml');
+        $path = realpath(__DIR__ . '/yaml/coverage_clover.yml');
 
         // Mocking command line options.
         $defs = new InputDefinition(
@@ -201,7 +201,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, array($this->cloverXmlPath1, $this->cloverXmlPath2));
 
-        $path = realpath(__DIR__.'/yaml/coverage_clover_glob.yml');
+        $path = realpath(__DIR__ . '/yaml/coverage_clover_glob.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -215,7 +215,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, array($this->cloverXmlPath1, $this->cloverXmlPath2));
 
-        $path = realpath(__DIR__.'/yaml/coverage_clover_array.yml');
+        $path = realpath(__DIR__ . '/yaml/coverage_clover_array.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -229,7 +229,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/json_path.yml');
+        $path = realpath(__DIR__ . '/yaml/json_path.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -243,7 +243,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/json_path.yml');
+        $path = realpath(__DIR__ . '/yaml/json_path.yml');
 
         // Mocking command line options.
         $defs = new InputDefinition(
@@ -272,7 +272,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/exclude_no_stmt_true.yml');
+        $path = realpath(__DIR__ . '/yaml/exclude_no_stmt_true.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -286,7 +286,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/exclude_no_stmt_false.yml');
+        $path = realpath(__DIR__ . '/yaml/exclude_no_stmt_false.yml');
 
         $config = $this->object->load($path, $this->rootDir);
 
@@ -303,7 +303,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/coverage_clover_not_found.yml');
+        $path = realpath(__DIR__ . '/yaml/coverage_clover_not_found.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -316,7 +316,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/coverage_clover_invalid.yml');
+        $path = realpath(__DIR__ . '/yaml/coverage_clover_invalid.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -331,7 +331,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/json_path_not_found.yml');
+        $path = realpath(__DIR__ . '/yaml/json_path_not_found.yml');
 
         $this->object->load($path, $this->rootDir);
     }
@@ -346,7 +346,7 @@ class ConfiguratorTest extends ProjectTestCase
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
-        $path = realpath(__DIR__.'/yaml/exclude_no_stmt_invalid.yml');
+        $path = realpath(__DIR__ . '/yaml/exclude_no_stmt_invalid.yml');
 
         $this->object->load($path, $this->rootDir);
     }

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
@@ -239,6 +239,35 @@ class ConfiguratorTest extends ProjectTestCase
     /**
      * @test
      */
+    public function shouldLoadJsonPathOverriddenByInput()
+    {
+        $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
+
+        $path = realpath(__DIR__ . '/yaml/json_path.yml');
+
+        // Mocking command line options.
+        $defs = new InputDefinition(
+            array(
+                new InputOption(
+                    'json_path',
+                    'j',
+                    InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY
+                ),
+            )
+        );
+        $inputArray = array(
+            '--json_path' => array(
+                'build/logs/coveralls-upload.json'
+            ),
+        );
+        $input = new ArrayInput($inputArray, $defs);
+        $config = $this->object->load($path, $this->rootDir, $input);
+        $this->assertConfiguration($config, array($this->cloverXmlPath), $this->jsonPath);
+    }
+
+    /**
+     * @test
+     */
     public function shouldLoadExcludeNoStmtYmlContainingTrue()
     {
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);


### PR DESCRIPTION
Hello,

I would like to customize the input file `clover.xml` and output file `coveralls-upload.json`. There was already an option (`--coverage_clover=YOUR_PATH.xml`) to configure the first one, but not to the second one.

Then, I created it :D .. with my changes, it is possible to configure the output json file with the `--json_path` command option:

1. I run local tests and they all pass
2. You can see [in this build](https://travis-ci.org/bauhausphp/package-common/builds/123247375) a successful integration travis and [coveralls](https://coveralls.io/builds/5798062) ([here](https://github.com/bauhausphp/package-common/blob/master/.travis.yml) is the `.travis.yml` I used).

I don't know if the option name I created is good, maybe it could be `--coveralls_upload_json`.

I hope that it is useful and that is going to be merged soon :)

[]s 