### PR TITLE
Add PHP7.1 for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
         - php: 5.6
         - php: 7.0
           env: CHECKS=yes
+        - php: 7.1
+          env: CHECKS=yes
         - php: hhvm
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ install:
 
 script:
     - cp ${HOME}/xdebug.ini ${HOME}/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini || return 0
-    - phpunit --version
     - phpunit
     - rm ${HOME}/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini || return 0
     - if [ "$CHECKS" = "yes" ]; then composer sca; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
 script:
     - cp ${HOME}/xdebug.ini ${HOME}/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini || return 0
-    - phpunit
+    - phpunit -v
     - rm ${HOME}/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini || return 0
     - if [ "$CHECKS" = "yes" ]; then composer sca; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
           env: 'BOX=yes'
         - php: 5.6
         - php: 7.0
-          env: CHECKS=yes
         - php: 7.1
           env: CHECKS=yes
         - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
 
 script:
     - cp ${HOME}/xdebug.ini ${HOME}/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini || return 0
+    - phpunit --version
     - phpunit
     - rm ${HOME}/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini || return 0
     - if [ "$CHECKS" = "yes" ]; then composer sca; fi;

--- a/circle.yml
+++ b/circle.yml
@@ -1,18 +1,17 @@
 machine:
   php:
     version:
-      5.5.31
+      7.1.0
 
 dependencies:
   override:
     - mkdir -p build/logs
     - echo "date.timezone = America/Los_Angeles" > /opt/circleci/php/$(phpenv global)/etc/conf.d/date.ini
     - composer update --prefer-stable --prefer-lowest --no-interaction
-    - composer install-devtools
     - phpenv versions
 
 test:
   override:
-    - devtools/vendor/bin/phpunit
+    - phpunit
   post:
     - bin/coveralls -v --exclude-no-stmt

--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,18 @@
 machine:
-  timezone: America/Los_Angeles
   php:
-    version: 5.5.0
+    version:
+      5.5.31
 
 dependencies:
   override:
     - mkdir -p build/logs
+    - echo "date.timezone = America/Los_Angeles" > /opt/circleci/php/$(phpenv global)/etc/conf.d/date.ini
     - composer update --prefer-stable --prefer-lowest --no-interaction
-    - sed -i 's/^;//' ~/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini
+    - composer install-devtools
+    - phpenv versions
 
 test:
   override:
-    - phpunit
+    - devtools/vendor/bin/phpunit
   post:
     - bin/coveralls -v --exclude-no-stmt

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ dependencies:
     - mkdir -p build/logs
     - echo "date.timezone = America/Los_Angeles" > /opt/circleci/php/$(phpenv global)/etc/conf.d/date.ini
     - composer update --prefer-stable --prefer-lowest --no-interaction
-    - phpenv versions
 
 test:
   override:

--- a/devtools/composer.json
+++ b/devtools/composer.json
@@ -7,6 +7,7 @@
         "friendsofphp/php-cs-fixer": "~2.1.0",
         "pdepend/pdepend": "^2.2",
         "phpmd/phpmd": "^2.3",
+        "phpunit/phpunit": "^4.5.0",
         "sebastian/finder-facade": "^1.1",
         "sebastian/phpcpd": "^1.4",
         "squizlabs/php_codesniffer": "^1.4",

--- a/devtools/composer.json
+++ b/devtools/composer.json
@@ -7,7 +7,6 @@
         "friendsofphp/php-cs-fixer": "~2.1.0",
         "pdepend/pdepend": "^2.2",
         "phpmd/phpmd": "^2.3",
-        "phpunit/phpunit": "^4.5.0",
         "sebastian/finder-facade": "^1.1",
         "sebastian/phpcpd": "^1.4",
         "squizlabs/php_codesniffer": "^1.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="vendor/autoload.php">
+         bootstrap="tests/bootstrap.php">
     <php>
         <ini name="error_reporting" value="E_ALL" />
     </php>

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
@@ -70,7 +70,11 @@ class JobsTest extends ProjectTestCase
 
     protected function createAdapterMockNeverCalled()
     {
-        $client = $this->getMock('GuzzleHttp\Client', ['send']);
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $client = $this->createPartialMock('GuzzleHttp\Client', array('send'));
+        } else {
+            $client = $this->getMock('GuzzleHttp\Client', array('send'));
+        }
 
         $client
         ->expects($this->never())
@@ -81,8 +85,13 @@ class JobsTest extends ProjectTestCase
 
     protected function createAdapterMockWith($url, $filename, $jsonPath)
     {
-        $client = $this->getMock('GuzzleHttp\Client', ['post']);
-        $response = $this->getMock('GuzzleHttp\Psr7\Response');
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $client = $this->createPartialMock('GuzzleHttp\Client', array('post'));
+            $response = $this->createMock('GuzzleHttp\Psr7\Response');
+        } else {
+            $client = $this->getMock('GuzzleHttp\Client', array('post'));
+            $response = $this->getMock('GuzzleHttp\Psr7\Response');
+        }
 
         $client
         ->expects($this->once())

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
@@ -70,44 +70,31 @@ class JobsTest extends ProjectTestCase
 
     protected function createAdapterMockNeverCalled()
     {
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $client = $this->createPartialMock('GuzzleHttp\Client', array('send'));
-        } else {
-            $client = $this->getMock('GuzzleHttp\Client', array('send'));
-        }
-
+        $client = $this->prophesize('\GuzzleHttp\Client');
         $client
-        ->expects($this->never())
-        ->method('send');
+            ->send()
+            ->shouldNotBeCalled();
 
-        return $client;
+        return $client->reveal();
     }
 
     protected function createAdapterMockWith($url, $filename, $jsonPath)
     {
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $client = $this->createPartialMock('GuzzleHttp\Client', array('post'));
-            $response = $this->createMock('GuzzleHttp\Psr7\Response');
-        } else {
-            $client = $this->getMock('GuzzleHttp\Client', array('post'));
-            $response = $this->getMock('GuzzleHttp\Psr7\Response');
-        }
+        $response = $this->prophesize('\GuzzleHttp\Psr7\Response');
+        $response->reveal();
 
+        $client = $this->prophesize('\GuzzleHttp\Client');
         $client
-        ->expects($this->once())
-        ->method('post')
-        ->with(
-            $this->equalTo($url),
-            $this->callback(function ($options) use ($filename) {
+            ->post($url, \Prophecy\Argument::that(function ($options) use ($filename) {
                 return !empty($options['multipart'][0]['name'])
                     && !empty($options['multipart'][0]['contents'])
                     && $options['multipart'][0]['name'] === $filename
                     && is_resource($options['multipart'][0]['contents']);
-            })
-        )
-        ->willReturn($response);
+            }))
+            ->willReturn($response)
+            ->shouldBeCalled();
 
-        return $client;
+        return $client->reveal();
     }
 
     protected function createConfiguration()

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
@@ -35,83 +35,75 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    protected function createGitCommandStub()
-    {
-        $class = 'Satooshi\Component\System\Git\GitCommand';
-
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            return $this->createMock($class);
-        }
-
-        return $this->getMock($class);
-    }
-
     protected function createGitCommandStubWith($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
     {
-        $stub = $this->createGitCommandStub();
+        $stub = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
 
         $this->setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue);
         $this->setUpGitCommandStubWithGetHeadCommitOnce($stub, $getHeadCommitValue);
         $this->setUpGitCommandStubWithGetRemotesOnce($stub, $getRemotesValue);
 
-        return $stub;
+        return $stub->reveal();
     }
 
     protected function createGitCommandStubCalledBranches($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
     {
-        $stub = $this->createGitCommandStub();
+        $stub = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
 
         $this->setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue);
         $this->setUpGitCommandStubWithGetHeadCommitNeverCalled($stub, $getHeadCommitValue);
         $this->setUpGitCommandStubWithGetRemotesNeverCalled($stub, $getRemotesValue);
 
-        return $stub;
+        return $stub->reveal();
     }
 
     protected function createGitCommandStubCalledHeadCommit($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
     {
-        $stub = $this->createGitCommandStub();
+        $stub = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
 
         $this->setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue);
         $this->setUpGitCommandStubWithGetHeadCommitOnce($stub, $getHeadCommitValue);
         $this->setUpGitCommandStubWithGetRemotesNeverCalled($stub, $getRemotesValue);
 
-        return $stub;
+        return $stub->reveal();
     }
 
     protected function setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue)
     {
-        $stub->expects($this->once())
-        ->method('getBranches')
-        ->will($this->returnValue($getBranchesValue));
+        $stub
+            ->getBranches()
+            ->willReturn($getBranchesValue)
+            ->shouldBeCalled();
     }
 
     protected function setUpGitCommandStubWithGetHeadCommitOnce($stub, $getHeadCommitValue)
     {
-        $stub->expects($this->once())
-        ->method('getHeadCommit')
-        ->will($this->returnValue($getHeadCommitValue));
+        $stub
+            ->getHeadCommit()
+            ->willReturn($getHeadCommitValue)
+            ->shouldBeCalled();
     }
 
     protected function setUpGitCommandStubWithGetHeadCommitNeverCalled($stub, $getHeadCommitValue)
     {
-        $stub->expects($this->never())
-        ->method('getHeadCommit')
-        ->will($this->returnValue($getHeadCommitValue));
+        $stub
+            ->getHeadCommit()
+            ->shouldNotBeCalled();
     }
 
     protected function setUpGitCommandStubWithGetRemotesOnce($stub, $getRemotesValue)
     {
-        $stub->expects($this->once())
-        ->method('getRemotes')
-        ->will($this->returnValue($getRemotesValue));
+        $stub
+            ->getRemotes()
+            ->willReturn($getRemotesValue)
+            ->shouldBeCalled();
     }
 
     protected function setUpGitCommandStubWithGetRemotesNeverCalled($stub, $getRemotesValue)
     {
-        $stub->expects($this->never())
-        ->method('getRemotes')
-        ->will($this->returnValue($getRemotesValue));
+        $stub
+            ->getRemotes()
+            ->shouldNotBeCalled();
     }
 
     // getCommand()

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
@@ -39,6 +39,10 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
     {
         $class = 'Satooshi\Component\System\Git\GitCommand';
 
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            return $this->createMock($class);
+        }
+
         return $this->getMock($class);
     }
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -27,14 +27,14 @@ class JobsRepositoryTest extends ProjectTestCase
 
     private function setUpJobsApiMethods()
     {
-        return array(
+        return [
             'collectCloverXml',
             'getJsonFile',
             'collectGitInfo',
             'collectEnvVars',
             'dumpJsonFile',
             'send',
-        );
+        ];
     }
 
     private function setUpJobsApiWithCollectCloverXmlCalled($api)
@@ -287,14 +287,14 @@ class JobsRepositoryTest extends ProjectTestCase
     public function shouldPersist()
     {
         $statusCode = 200;
-        $url        = 'https://coveralls.io/jobs/67528';
-        $response   = new \GuzzleHttp\Psr7\Response(
-            $statusCode, array(), json_encode(array(
+        $url = 'https://coveralls.io/jobs/67528';
+        $response = new \GuzzleHttp\Psr7\Response(
+            $statusCode, [], json_encode([
                 'message' => 'Job #115.3',
-                'url'     => $url,
-            )), '1.1', 'OK'
+                'url' => $url,
+            ]), '1.1', 'OK'
         );
-        $api    = $this->createApiMock($response, $statusCode, $url);
+        $api = $this->createApiMock($response, $statusCode, $url);
         $config = $this->createConfiguration();
         $logger = $this->createLoggerMock();
 
@@ -377,14 +377,14 @@ class JobsRepositoryTest extends ProjectTestCase
     public function response422()
     {
         $statusCode = 422;
-        $response   = new \GuzzleHttp\Psr7\Response(
-            $statusCode, array(), json_encode(array(
+        $response = new \GuzzleHttp\Psr7\Response(
+            $statusCode, [], json_encode([
                 'message' => 'Build processing error.',
-                'url'     => '',
-                'error'   => true,
-            )), '1.1', 'Unprocessable Entity'
+                'url' => '',
+                'error' => true,
+            ]), '1.1', 'Unprocessable Entity'
         );
-        $api    = $this->createApiMock($response, $statusCode);
+        $api = $this->createApiMock($response, $statusCode);
         $config = $this->createConfiguration();
         $logger = $this->createLoggerMock();
 
@@ -402,10 +402,10 @@ class JobsRepositoryTest extends ProjectTestCase
     public function response500()
     {
         $statusCode = 500;
-        $response   = new \GuzzleHttp\Psr7\Response($statusCode, array(), null, '1.1', 'Internal Server Error');
-        $api        = $this->createApiMock($response, $statusCode);
-        $config     = $this->createConfiguration();
-        $logger     = $this->createLoggerMock();
+        $response = new \GuzzleHttp\Psr7\Response($statusCode, [], null, '1.1', 'Internal Server Error');
+        $api = $this->createApiMock($response, $statusCode);
+        $config = $this->createConfiguration();
+        $logger = $this->createLoggerMock();
 
         $object = new JobsRepository($api, $config);
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -25,9 +25,9 @@ class JobsRepositoryTest extends ProjectTestCase
 
     // mock
 
-    protected function createApiMockWithRequirementsNotSatisfiedException()
+    private function setUpJobsApiMethods()
     {
-        $jobsMethods = array(
+        return array(
             'collectCloverXml',
             'getJsonFile',
             'collectGitInfo',
@@ -35,156 +35,98 @@ class JobsRepositoryTest extends ProjectTestCase
             'dumpJsonFile',
             'send',
         );
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
-        } else {
-            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-            ->disableOriginalConstructor()
-            ->setMethods($jobsMethods)
-            ->getMock();
-        }
-
-        $exception = new RequirementsNotSatisfiedException();
-
-        $api
-        ->expects($this->once())
-        ->method('collectCloverXml')
-        ->with()
-        ->will($this->throwException($exception));
-
-        $api
-        ->expects($this->never())
-        ->method('getJsonFile');
-
-        $api
-        ->expects($this->never())
-        ->method('collectGitInfo');
-
-        $api
-        ->expects($this->never())
-        ->method('collectEnvVars');
-
-        $api
-        ->expects($this->never())
-        ->method('dumpJsonFile');
-
-        $api
-        ->expects($this->never())
-        ->method('send');
-
-        return $api;
     }
 
-    protected function createApiMockWithException()
+    private function setUpJobsApiWithCollectCloverXmlCalled($api)
     {
-        $jobsMethods = array(
-            'collectCloverXml',
-            'getJsonFile',
-            'collectGitInfo',
-            'collectEnvVars',
-            'dumpJsonFile',
-            'send',
-        );
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
-        } else {
-            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-            ->disableOriginalConstructor()
-            ->setMethods($jobsMethods)
-            ->getMock();
-        }
-
-        $message = 'unexpected exception';
-        $exception = new \Exception($message);
-
         $api
-        ->expects($this->once())
-        ->method('collectCloverXml')
-        ->with()
-        ->will($this->throwException($exception));
-
-        $api
-        ->expects($this->never())
-        ->method('getJsonFile');
-
-        $api
-        ->expects($this->never())
-        ->method('collectGitInfo');
-
-        $api
-        ->expects($this->never())
-        ->method('collectEnvVars');
-
-        $api
-        ->expects($this->never())
-        ->method('dumpJsonFile');
-
-        $api
-        ->expects($this->never())
-        ->method('send');
-
-        return $api;
+            ->expects($this->once())
+            ->method('collectCloverXml')
+            ->with()
+            ->will($this->returnSelf());
     }
 
-    protected function createApiMock($response, $statusCode = 200, $uri = '/')
+    private function setUpJobsApiWithCollectCloverXmlThrow($api, $exception)
     {
-        $jsonFile = $this->createJsonFile();
-
-        $jobsMethods = array(
-            'collectCloverXml',
-            'getJsonFile',
-            'collectGitInfo',
-            'collectEnvVars',
-            'dumpJsonFile',
-            'send',
-        );
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
-        } else {
-            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-            ->disableOriginalConstructor()
-            ->setMethods($jobsMethods)
-            ->getMock();
-        }
-
         $api
-        ->expects($this->once())
-        ->method('collectCloverXml')
-        ->with()
-        ->will($this->returnSelf());
+            ->expects($this->once())
+            ->method('collectCloverXml')
+            ->with()
+            ->will($this->throwException($exception));
+    }
 
+    private function setUpJobsApiWithGetJsonFileCalled($api, $jsonFile)
+    {
         $api
-        ->expects($this->once())
-        ->method('getJsonFile')
-        ->with()
-        ->will($this->returnValue($jsonFile));
+            ->expects($this->once())
+            ->method('getJsonFile')
+            ->with()
+            ->will($this->returnValue($jsonFile));
+    }
 
+    private function setUpJobsApiWithGetJsonFileNotCalled($api)
+    {
         $api
-        ->expects($this->once())
-        ->method('collectGitInfo')
-        ->with()
-        ->will($this->returnSelf());
+            ->expects($this->never())
+            ->method('getJsonFile');
+    }
 
+    private function setUpJobsApiWithCollectGitInfoCalled($api)
+    {
         $api
-        ->expects($this->once())
-        ->method('collectEnvVars')
-        ->with($this->equalTo($_SERVER))
-        ->will($this->returnSelf());
+            ->expects($this->once())
+            ->method('collectGitInfo')
+            ->with()
+            ->will($this->returnSelf());
+    }
 
+    private function setUpJobsApiWithCollectGitInfoNotCalled($api)
+    {
         $api
-        ->expects($this->once())
-        ->method('dumpJsonFile')
-        ->with()
-        ->will($this->returnSelf());
+            ->expects($this->never())
+            ->method('collectGitInfo');
+    }
 
-        $request = new \GuzzleHttp\Psr7\Request('POST', $uri);
+    private function setUpJobsApiWithCollectEnvVarsCalled($api)
+    {
+        $api
+            ->expects($this->once())
+            ->method('collectEnvVars')
+            ->with($this->equalTo($_SERVER))
+            ->will($this->returnSelf());
+    }
 
+    private function setUpJobsApiWithCollectEnvVarsNotCalled($api)
+    {
+        $api
+            ->expects($this->never())
+            ->method('collectEnvVars');
+    }
+
+    private function setUpJobsApiWithDumpJsonFileCalled($api)
+    {
+        $api
+            ->expects($this->once())
+            ->method('dumpJsonFile')
+            ->with()
+            ->will($this->returnSelf());
+    }
+
+    private function setUpJobsApiWithDumpJsonFileNotCalled($api)
+    {
+        $api
+            ->expects($this->never())
+            ->method('dumpJsonFile');
+    }
+
+    private function setUpJobsApiWithSendCalled($api, $statusCode, $request, $response)
+    {
         if ($statusCode === 200) {
             $api
-            ->expects($this->once())
-            ->method('send')
-            ->with()
-            ->will($this->returnValue($response));
+                ->expects($this->once())
+                ->method('send')
+                ->with()
+                ->will($this->returnValue($response));
         } else {
             if ($statusCode === null) {
                 $exception = \GuzzleHttp\Exception\ConnectException::create($request);
@@ -195,11 +137,85 @@ class JobsRepositoryTest extends ProjectTestCase
             }
 
             $api
-            ->expects($this->once())
-            ->method('send')
-            ->with()
-            ->will($this->throwException($exception));
+                ->expects($this->once())
+                ->method('send')
+                ->with()
+                ->will($this->throwException($exception));
         }
+    }
+
+    private function setUpJobsApiWithSendNotCalled($api)
+    {
+        $api
+            ->expects($this->never())
+            ->method('send');
+    }
+
+    protected function createApiMockWithRequirementsNotSatisfiedException()
+    {
+        $jobsMethods = $this->setUpJobsApiMethods();
+
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
+        } else {
+            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
+            ->disableOriginalConstructor()
+            ->setMethods($jobsMethods)
+            ->getMock();
+        }
+
+        $this->setUpJobsApiWithCollectCloverXmlThrow($api, new RequirementsNotSatisfiedException());
+        $this->setUpJobsApiWithGetJsonFileNotCalled($api);
+        $this->setUpJobsApiWithCollectGitInfoNotCalled($api);
+        $this->setUpJobsApiWithCollectEnvVarsNotCalled($api);
+        $this->setUpJobsApiWithDumpJsonFileNotCalled($api);
+        $this->setUpJobsApiWithSendNotCalled($api);
+
+        return $api;
+    }
+
+    protected function createApiMockWithException()
+    {
+        $jobsMethods = $this->setUpJobsApiMethods();
+
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
+        } else {
+            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
+            ->disableOriginalConstructor()
+            ->setMethods($jobsMethods)
+            ->getMock();
+        }
+
+        $this->setUpJobsApiWithCollectCloverXmlThrow($api, new \Exception('unexpected exception'));
+        $this->setUpJobsApiWithGetJsonFileNotCalled($api);
+        $this->setUpJobsApiWithCollectGitInfoNotCalled($api);
+        $this->setUpJobsApiWithCollectEnvVarsNotCalled($api);
+        $this->setUpJobsApiWithDumpJsonFileNotCalled($api);
+        $this->setUpJobsApiWithSendNotCalled($api);
+
+        return $api;
+    }
+
+    protected function createApiMock($response, $statusCode = '', $uri = '/')
+    {
+        $jobsMethods = $this->setUpJobsApiMethods();
+
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
+        } else {
+            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
+            ->disableOriginalConstructor()
+            ->setMethods($jobsMethods)
+            ->getMock();
+        }
+
+        $this->setUpJobsApiWithCollectCloverXmlCalled($api);
+        $this->setUpJobsApiWithGetJsonFileCalled($api, $this->createJsonFile());
+        $this->setUpJobsApiWithCollectGitInfoCalled($api);
+        $this->setUpJobsApiWithCollectEnvVarsCalled($api);
+        $this->setUpJobsApiWithDumpJsonFileCalled($api);
+        $this->setUpJobsApiWithSendCalled($api, $statusCode, new \GuzzleHttp\Psr7\Request('POST', $uri), $response);
 
         return $api;
     }
@@ -271,10 +287,16 @@ class JobsRepositoryTest extends ProjectTestCase
     public function shouldPersist()
     {
         $statusCode = 200;
-        $response   = new \GuzzleHttp\Psr7\Response($statusCode);
-        $api        = $this->createApiMock($response, $statusCode, 'https://coveralls.io/jobs/67528');
-        $config     = $this->createConfiguration();
-        $logger     = $this->createLoggerMock();
+        $url        = 'https://coveralls.io/jobs/67528';
+        $response   = new \GuzzleHttp\Psr7\Response(
+            $statusCode, array(), json_encode(array(
+                'message' => 'Job #115.3',
+                'url'     => $url,
+            )), '1.1', 'OK'
+        );
+        $api    = $this->createApiMock($response, $statusCode, $url);
+        $config = $this->createConfiguration();
+        $logger = $this->createLoggerMock();
 
         $object = new JobsRepository($api, $config);
 
@@ -355,10 +377,16 @@ class JobsRepositoryTest extends ProjectTestCase
     public function response422()
     {
         $statusCode = 422;
-        $response   = new \GuzzleHttp\Psr7\Response($statusCode);
-        $api        = $this->createApiMock($response, $statusCode);
-        $config     = $this->createConfiguration();
-        $logger     = $this->createLoggerMock();
+        $response   = new \GuzzleHttp\Psr7\Response(
+            $statusCode, array(), json_encode(array(
+                'message' => 'Build processing error.',
+                'url'     => '',
+                'error'   => true,
+            )), '1.1', 'Unprocessable Entity'
+        );
+        $api    = $this->createApiMock($response, $statusCode);
+        $config = $this->createConfiguration();
+        $logger = $this->createLoggerMock();
 
         $object = new JobsRepository($api, $config);
 
@@ -374,7 +402,7 @@ class JobsRepositoryTest extends ProjectTestCase
     public function response500()
     {
         $statusCode = 500;
-        $response   = new \GuzzleHttp\Psr7\Response($statusCode);
+        $response   = new \GuzzleHttp\Psr7\Response($statusCode, array(), null, '1.1', 'Internal Server Error');
         $api        = $this->createApiMock($response, $statusCode);
         $config     = $this->createConfiguration();
         $logger     = $this->createLoggerMock();

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -118,7 +118,7 @@ class JobsRepositoryTest extends ProjectTestCase
         return $api;
     }
 
-    protected function createApiMock($response, $statusCode = 200)
+    protected function createApiMock($response, $statusCode = 200, $uri = '/')
     {
         $jsonFile = $this->createJsonFile();
 
@@ -165,9 +165,7 @@ class JobsRepositoryTest extends ProjectTestCase
         ->with()
         ->will($this->returnSelf());
 
-        $request = $this->getMockBuilder('\GuzzleHttp\Psr7\Request')
-        ->setConstructorArgs(['POST', '/'])
-        ->getMock();
+        $request = new \GuzzleHttp\Psr7\Request('POST', $uri);
 
         if ($statusCode === 200) {
             $api
@@ -192,48 +190,6 @@ class JobsRepositoryTest extends ProjectTestCase
         }
 
         return $api;
-    }
-
-    protected function createResponseMock($statusCode, $reasonPhrase, $body)
-    {
-        $json = is_array($body) ? json_encode($body) : $body;
-
-        $response = $this->getMockBuilder('\GuzzleHttp\Psr7\Response')
-            ->setMethods([
-                'getStatusCode',
-                'getReasonPhrase',
-                'getBody',
-            ])
-            ->getMock();
-
-        $stream = $this->getMockBuilder('\GuzzleHttp\Psr7\Stream')
-            ->setMethods(['__toString'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $response
-            ->expects($this->atLeastOnce())
-            ->method('getStatusCode')
-            ->with()
-            ->will($this->returnValue($statusCode));
-
-        $response
-            ->expects($this->atLeastOnce())
-            ->method('getReasonPhrase')
-            ->with()
-            ->will($this->returnValue($reasonPhrase));
-
-        $response
-            ->expects($this->atLeastOnce())
-            ->method('getBody')
-            ->will($this->returnValue($stream));
-
-        $stream
-            ->expects($this->atLeastOnce())
-            ->method('__toString')
-            ->will($this->returnValue($json));
-
-        return $response;
     }
 
     protected function createLoggerMock()
@@ -309,11 +265,10 @@ class JobsRepositoryTest extends ProjectTestCase
     public function shouldPersist()
     {
         $statusCode = 200;
-        $json = ['message' => 'Job #115.3', 'url' => 'https://coveralls.io/jobs/67528'];
-        $response = $this->createResponseMock($statusCode, 'OK', $json);
-        $api = $this->createApiMock($response, $statusCode);
-        $config = $this->createConfiguration();
-        $logger = $this->createLoggerMock();
+        $response   = new \GuzzleHttp\Psr7\Response($statusCode);
+        $api        = $this->createApiMock($response, $statusCode, 'https://coveralls.io/jobs/67528');
+        $config     = $this->createConfiguration();
+        $logger     = $this->createLoggerMock();
 
         $object = new JobsRepository($api, $config);
 
@@ -394,11 +349,10 @@ class JobsRepositoryTest extends ProjectTestCase
     public function response422()
     {
         $statusCode = 422;
-        $json = ['message' => 'Build processing error.', 'url' => '', 'error' => true];
-        $response = $this->createResponseMock($statusCode, 'Unprocessable Entity', $json);
-        $api = $this->createApiMock($response, $statusCode);
-        $config = $this->createConfiguration();
-        $logger = $this->createLoggerMock();
+        $response   = new \GuzzleHttp\Psr7\Response($statusCode);
+        $api        = $this->createApiMock($response, $statusCode);
+        $config     = $this->createConfiguration();
+        $logger     = $this->createLoggerMock();
 
         $object = new JobsRepository($api, $config);
 
@@ -414,10 +368,10 @@ class JobsRepositoryTest extends ProjectTestCase
     public function response500()
     {
         $statusCode = 500;
-        $response = $this->createResponseMock($statusCode, 'Internal Server Error', 'response');
-        $api = $this->createApiMock($response, $statusCode);
-        $config = $this->createConfiguration();
-        $logger = $this->createLoggerMock();
+        $response   = new \GuzzleHttp\Psr7\Response($statusCode);
+        $api        = $this->createApiMock($response, $statusCode);
+        $config     = $this->createConfiguration();
+        $logger     = $this->createLoggerMock();
 
         $object = new JobsRepository($api, $config);
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -206,23 +206,13 @@ class JobsRepositoryTest extends ProjectTestCase
 
     protected function createLoggerMock()
     {
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $logger = $this->createPartialMock('Psr\Log\NullLogger', array('info', 'error'));
-        } else {
-            $logger = $this->getMock('Psr\Log\NullLogger', array('info', 'error'));
-        }
-
+        $logger = $this->prophesize('\Psr\Log\NullLogger');
         $logger
-        ->expects($this->any())
-        ->method('info')
-        ->with();
-
+            ->info();
         $logger
-        ->expects($this->any())
-        ->method('error')
-        ->with();
+            ->error();
 
-        return $logger;
+        return $logger->reveal();
     }
 
     // dependent object

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -25,108 +25,97 @@ class JobsRepositoryTest extends ProjectTestCase
 
     // mock
 
-    private function setUpJobsApiMethods()
-    {
-        return [
-            'collectCloverXml',
-            'getJsonFile',
-            'collectGitInfo',
-            'collectEnvVars',
-            'dumpJsonFile',
-            'send',
-        ];
-    }
-
     private function setUpJobsApiWithCollectCloverXmlCalled($api)
     {
         $api
-            ->expects($this->once())
-            ->method('collectCloverXml')
-            ->with()
-            ->will($this->returnSelf());
+            ->collectCloverXml()
+            ->will(function () {
+                return $this;
+            })
+            ->shouldBeCalled();
     }
 
     private function setUpJobsApiWithCollectCloverXmlThrow($api, $exception)
     {
         $api
-            ->expects($this->once())
-            ->method('collectCloverXml')
-            ->with()
-            ->will($this->throwException($exception));
+            ->collectCloverXml()
+            ->willThrow($exception)
+            ->shouldBeCalled();
     }
 
     private function setUpJobsApiWithGetJsonFileCalled($api, $jsonFile)
     {
         $api
-            ->expects($this->once())
-            ->method('getJsonFile')
-            ->with()
-            ->will($this->returnValue($jsonFile));
+            ->getJsonFile()
+            ->willReturn($jsonFile)
+            ->shouldBeCalled();
     }
 
     private function setUpJobsApiWithGetJsonFileNotCalled($api)
     {
         $api
-            ->expects($this->never())
-            ->method('getJsonFile');
+            ->getJsonFile()
+            ->shouldNotBeCalled();
     }
 
     private function setUpJobsApiWithCollectGitInfoCalled($api)
     {
         $api
-            ->expects($this->once())
-            ->method('collectGitInfo')
-            ->with()
-            ->will($this->returnSelf());
+            ->collectGitInfo()
+            ->will(function () {
+                return $this;
+            })
+            ->shouldBeCalled();
     }
 
     private function setUpJobsApiWithCollectGitInfoNotCalled($api)
     {
         $api
-            ->expects($this->never())
-            ->method('collectGitInfo');
+            ->collectGitInfo()
+            ->shouldNotBeCalled();
     }
 
     private function setUpJobsApiWithCollectEnvVarsCalled($api)
     {
         $api
-            ->expects($this->once())
-            ->method('collectEnvVars')
-            ->with($this->equalTo($_SERVER))
-            ->will($this->returnSelf());
+            ->collectEnvVars($_SERVER)
+            ->will(function () {
+                return $this;
+            })
+            ->shouldBeCalled();
     }
 
     private function setUpJobsApiWithCollectEnvVarsNotCalled($api)
     {
         $api
-            ->expects($this->never())
-            ->method('collectEnvVars');
+            ->collectEnvVars()
+            ->shouldNotBeCalled();
     }
 
     private function setUpJobsApiWithDumpJsonFileCalled($api)
     {
         $api
-            ->expects($this->once())
-            ->method('dumpJsonFile')
-            ->with()
-            ->will($this->returnSelf());
+            ->dumpJsonFile()
+            ->will(function () {
+                return $this;
+            })
+            ->shouldBeCalled();
     }
 
     private function setUpJobsApiWithDumpJsonFileNotCalled($api)
     {
         $api
-            ->expects($this->never())
-            ->method('dumpJsonFile');
+            ->dumpJsonFile()
+            ->shouldNotBeCalled();
     }
 
     private function setUpJobsApiWithSendCalled($api, $statusCode, $request, $response)
     {
         if ($statusCode === 200) {
             $api
-                ->expects($this->once())
-                ->method('send')
-                ->with()
-                ->will($this->returnValue($response));
+                ->send()
+                ->willReturn($response)
+                ->shouldBeCalled();
         } else {
             if ($statusCode === null) {
                 $exception = \GuzzleHttp\Exception\ConnectException::create($request);
@@ -137,33 +126,22 @@ class JobsRepositoryTest extends ProjectTestCase
             }
 
             $api
-                ->expects($this->once())
-                ->method('send')
-                ->with()
-                ->will($this->throwException($exception));
+                ->send()
+                ->willThrow($exception)
+                ->shouldBeCalled();
         }
     }
 
     private function setUpJobsApiWithSendNotCalled($api)
     {
         $api
-            ->expects($this->never())
-            ->method('send');
+            ->send()
+            ->shouldNotBeCalled();
     }
 
     protected function createApiMockWithRequirementsNotSatisfiedException()
     {
-        $jobsMethods = $this->setUpJobsApiMethods();
-
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
-        } else {
-            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-            ->disableOriginalConstructor()
-            ->setMethods($jobsMethods)
-            ->getMock();
-        }
-
+        $api = $this->prophesize('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs');
         $this->setUpJobsApiWithCollectCloverXmlThrow($api, new RequirementsNotSatisfiedException());
         $this->setUpJobsApiWithGetJsonFileNotCalled($api);
         $this->setUpJobsApiWithCollectGitInfoNotCalled($api);
@@ -171,22 +149,12 @@ class JobsRepositoryTest extends ProjectTestCase
         $this->setUpJobsApiWithDumpJsonFileNotCalled($api);
         $this->setUpJobsApiWithSendNotCalled($api);
 
-        return $api;
+        return $api->reveal();
     }
 
     protected function createApiMockWithException()
     {
-        $jobsMethods = $this->setUpJobsApiMethods();
-
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
-        } else {
-            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-            ->disableOriginalConstructor()
-            ->setMethods($jobsMethods)
-            ->getMock();
-        }
-
+        $api = $this->prophesize('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs');
         $this->setUpJobsApiWithCollectCloverXmlThrow($api, new \Exception('unexpected exception'));
         $this->setUpJobsApiWithGetJsonFileNotCalled($api);
         $this->setUpJobsApiWithCollectGitInfoNotCalled($api);
@@ -194,22 +162,12 @@ class JobsRepositoryTest extends ProjectTestCase
         $this->setUpJobsApiWithDumpJsonFileNotCalled($api);
         $this->setUpJobsApiWithSendNotCalled($api);
 
-        return $api;
+        return $api->reveal();
     }
 
     protected function createApiMock($response, $statusCode = '', $uri = '/')
     {
-        $jobsMethods = $this->setUpJobsApiMethods();
-
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
-        } else {
-            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-            ->disableOriginalConstructor()
-            ->setMethods($jobsMethods)
-            ->getMock();
-        }
-
+        $api = $this->prophesize('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs');
         $this->setUpJobsApiWithCollectCloverXmlCalled($api);
         $this->setUpJobsApiWithGetJsonFileCalled($api, $this->createJsonFile());
         $this->setUpJobsApiWithCollectGitInfoCalled($api);
@@ -217,7 +175,7 @@ class JobsRepositoryTest extends ProjectTestCase
         $this->setUpJobsApiWithDumpJsonFileCalled($api);
         $this->setUpJobsApiWithSendCalled($api, $statusCode, new \GuzzleHttp\Psr7\Request('POST', $uri), $response);
 
-        return $api;
+        return $api->reveal();
     }
 
     protected function createLoggerMock()

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -27,18 +27,22 @@ class JobsRepositoryTest extends ProjectTestCase
 
     protected function createApiMockWithRequirementsNotSatisfiedException()
     {
-        $jobsMethods = [
+        $jobsMethods = array(
             'collectCloverXml',
             'getJsonFile',
             'collectGitInfo',
             'collectEnvVars',
             'dumpJsonFile',
             'send',
-        ];
-        $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-        ->disableOriginalConstructor()
-        ->setMethods($jobsMethods)
-        ->getMock();
+        );
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
+        } else {
+            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
+            ->disableOriginalConstructor()
+            ->setMethods($jobsMethods)
+            ->getMock();
+        }
 
         $exception = new RequirementsNotSatisfiedException();
 
@@ -73,18 +77,22 @@ class JobsRepositoryTest extends ProjectTestCase
 
     protected function createApiMockWithException()
     {
-        $jobsMethods = [
+        $jobsMethods = array(
             'collectCloverXml',
             'getJsonFile',
             'collectGitInfo',
             'collectEnvVars',
             'dumpJsonFile',
             'send',
-        ];
-        $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-        ->disableOriginalConstructor()
-        ->setMethods($jobsMethods)
-        ->getMock();
+        );
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
+        } else {
+            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
+            ->disableOriginalConstructor()
+            ->setMethods($jobsMethods)
+            ->getMock();
+        }
 
         $message = 'unexpected exception';
         $exception = new \Exception($message);
@@ -122,18 +130,22 @@ class JobsRepositoryTest extends ProjectTestCase
     {
         $jsonFile = $this->createJsonFile();
 
-        $jobsMethods = [
+        $jobsMethods = array(
             'collectCloverXml',
             'getJsonFile',
             'collectGitInfo',
             'collectEnvVars',
             'dumpJsonFile',
             'send',
-        ];
-        $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
-        ->disableOriginalConstructor()
-        ->setMethods($jobsMethods)
-        ->getMock();
+        );
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $api = $this->createPartialMock('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs', $jobsMethods);
+        } else {
+            $api = $this->getMockBuilder('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs')
+            ->disableOriginalConstructor()
+            ->setMethods($jobsMethods)
+            ->getMock();
+        }
 
         $api
         ->expects($this->once())
@@ -194,7 +206,11 @@ class JobsRepositoryTest extends ProjectTestCase
 
     protected function createLoggerMock()
     {
-        $logger = $this->getMock('Psr\Log\NullLogger', ['info', 'error']);
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $logger = $this->createPartialMock('Psr\Log\NullLogger', array('info', 'error'));
+        } else {
+            $logger = $this->getMock('Psr\Log\NullLogger', array('info', 'error'));
+        }
 
         $logger
         ->expects($this->any())

--- a/tests/Satooshi/Component/Log/ConsoleLoggerTest.php
+++ b/tests/Satooshi/Component/Log/ConsoleLoggerTest.php
@@ -11,21 +11,12 @@ class ConsoleLoggerTest extends \PHPUnit_Framework_TestCase
 {
     protected function createAdapterMockWith($message)
     {
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $mock = $this->createPartialMock('Symfony\Component\Console\Output\StreamOutput', array('writeln'));
-        } else {
-            $mock = $this->getMockBuilder('Symfony\Component\Console\Output\StreamOutput')
-            ->disableOriginalConstructor()
-            ->setMethods(array('writeln'))
-            ->getMock();
-        }
-
+        $mock = $this->prophesize('\Symfony\Component\Console\Output\StreamOutput');
         $mock
-        ->expects($this->once())
-        ->method('writeln')
-        ->with($this->equalTo($message));
+            ->writeln($message)
+            ->shouldBeCalled();
 
-        return $mock;
+        return $mock->reveal();
     }
 
     /**

--- a/tests/Satooshi/Component/Log/ConsoleLoggerTest.php
+++ b/tests/Satooshi/Component/Log/ConsoleLoggerTest.php
@@ -11,10 +11,14 @@ class ConsoleLoggerTest extends \PHPUnit_Framework_TestCase
 {
     protected function createAdapterMockWith($message)
     {
-        $mock = $this->getMockBuilder('Symfony\Component\Console\Output\StreamOutput')
-        ->disableOriginalConstructor()
-        ->setMethods(['writeln'])
-        ->getMock();
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $mock = $this->createPartialMock('Symfony\Component\Console\Output\StreamOutput', array('writeln'));
+        } else {
+            $mock = $this->getMockBuilder('Symfony\Component\Console\Output\StreamOutput')
+            ->disableOriginalConstructor()
+            ->setMethods(array('writeln'))
+            ->getMock();
+        }
 
         $mock
         ->expects($this->once())

--- a/tests/Satooshi/Component/System/Git/GitCommandTest.php
+++ b/tests/Satooshi/Component/System/Git/GitCommandTest.php
@@ -10,18 +10,35 @@ namespace Satooshi\Component\System\Git;
  */
 class GitCommandTest extends \PHPUnit_Framework_TestCase
 {
-    protected function createGitCommandMock($params)
+    protected function createGitBranchesCommandMock($params)
     {
         $adapter = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
         $adapter
             ->getBranches()
-            ->willReturn($params);
+            ->willReturn($params)
+            ->shouldBeCalled();
+
+        return $adapter->reveal();
+    }
+
+    protected function createGitHeadCommitCommandMock($params)
+    {
+        $adapter = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
         $adapter
             ->getHeadCommit()
-            ->willReturn($params);
+            ->willReturn($params)
+            ->shouldBeCalled();
+
+        return $adapter->reveal();
+    }
+
+    protected function createGitRemotesCommandMock($params)
+    {
+        $adapter = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
         $adapter
             ->getRemotes()
-            ->willReturn($params);
+            ->willReturn($params)
+            ->shouldBeCalled();
 
         return $adapter->reveal();
     }
@@ -48,9 +65,7 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldExecuteGitBranchCommand()
     {
-        $expected = 'git branch';
-
-        $object = $this->createGitCommandMock($expected);
+        $object = $this->createGitBranchesCommandMock('git branch');
         $object->getBranches();
     }
 
@@ -73,9 +88,7 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldExecuteGitLogCommand()
     {
-        $expected = "git log -1 --pretty=format:'%H%n%aN%n%ae%n%cN%n%ce%n%s'";
-
-        $object = $this->createGitCommandMock($expected);
+        $object = $this->createGitHeadCommitCommandMock("git log -1 --pretty=format:'%H%n%aN%n%ae%n%cN%n%ce%n%s'");
         $object->getHeadCommit();
     }
 
@@ -99,9 +112,7 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function shouldExecuteGitRemoteCommand()
     {
-        $expected = 'git remote -v';
-
-        $object = $this->createGitCommandMock($expected);
+        $object = $this->createGitRemotesCommandMock('git remote -v');
         $object->getRemotes();
     }
 

--- a/tests/Satooshi/Component/System/Git/GitCommandTest.php
+++ b/tests/Satooshi/Component/System/Git/GitCommandTest.php
@@ -12,19 +12,18 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
 {
     protected function createGitCommandMock($params)
     {
-        $class = 'Satooshi\Component\System\Git\GitCommand';
-        if (method_exists(__CLASS__, 'createPartialMock')) {
-            $adapter = $this->createPartialMock($class, array('executeCommand'));
-        } else {
-            $adapter = $this->getMock($class, array('executeCommand'));
-        }
-
+        $adapter = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
         $adapter
-            ->expects($this->once())
-            ->method('executeCommand')
-            ->with($this->equalTo($params));
+            ->getBranches()
+            ->willReturn($params);
+        $adapter
+            ->getHeadCommit()
+            ->willReturn($params);
+        $adapter
+            ->getRemotes()
+            ->willReturn($params);
 
-        return $adapter;
+        return $adapter->reveal();
     }
 
     // getCommandPath()

--- a/tests/Satooshi/Component/System/Git/GitCommandTest.php
+++ b/tests/Satooshi/Component/System/Git/GitCommandTest.php
@@ -13,7 +13,11 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
     protected function createGitCommandMock($params)
     {
         $class = 'Satooshi\Component\System\Git\GitCommand';
-        $adapter = $this->getMock($class, ['executeCommand']);
+        if (method_exists(__CLASS__, 'createPartialMock')) {
+            $adapter = $this->createPartialMock($class, array('executeCommand'));
+        } else {
+            $adapter = $this->getMock($class, array('executeCommand'));
+        }
 
         $adapter
             ->expects($this->once())

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!class_exists('PHPUnit_Framework_TestCase')) {
+    class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
+}
+
+require __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';


### PR DESCRIPTION
Thank you for #204 .
This time it will be PR added only for PHP 7.1 to the support version of TravisCI.

Just as I was testing, I needed to specify test cases and php-cs-fixer version.
I corrected it carefully, so thank you for your review.
