### PR TITLE
ErrorFix php-cs-fixer for TravisCI

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -4,8 +4,18 @@ return Symfony\CS\Config\Config::create()
     ->setUsingCache(true)
     // use default SYMFONY_LEVEL and change the set with fixers:
     ->fixers([
+        '-braces',
         '-concat_without_spaces',
+        '-extra_empty_lines',
+        '-hash_to_slash_comment',
+        '-heredoc_to_nowdoc',
+        '-no_empty_comment',
+        '-operators_spaces',
+        '-phpdoc_annotation_without_dot',
         '-phpdoc_no_package',
+        '-php_unit_fqcn_annotation',
+        '-spaces_after_semicolon',
+        '-trailing_spaces',
         '-unalign_double_arrow',
         '-unalign_equals',
         'concat_with_spaces',

--- a/devtools/composer.json
+++ b/devtools/composer.json
@@ -4,7 +4,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "apigen/apigen": "^2.8",
-        "fabpot/php-cs-fixer": "^1.11",
+        "friendsofphp/php-cs-fixer": "^1.11",
         "pdepend/pdepend": "^2.2",
         "phpmd/phpmd": "^2.3",
         "sebastian/finder-facade": "^1.1",

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -258,7 +258,7 @@ class JobsRepositoryTest extends ProjectTestCase
     {
         $jsonFile = new JsonFile();
 
-        $repositoryTestDir = $this->srcDir  . '/RepositoryTest';
+        $repositoryTestDir = $this->srcDir . '/RepositoryTest';
 
         $sourceFiles = array(
             0   => new SourceFile($repositoryTestDir . '/Coverage0.php',   'Coverage0.php'),


### PR DESCRIPTION
This pull request is fixed php-cs-fixer error.
I added a rule to .php_cs. We refactor separately with the project's policy.

*CHANGELOG*
* Occurred php_unit_fqcn_annotation error via php-cs-fixer v1.13.0
* Occurred braces, extra_empty_lines, hash_to_slash_comment, heredoc_to_nowdoc, no_empty_comment, phpdoc_annotation_without_dot, spaces_after_semicolon and trailing_spaces error via php-cs-fixer v1.12.0
* Occurred operators_spaces error via php-cs-fixer v1.11.7
* Occurred concat_with_spaces error via php-cs-fixer v1.11.5