### PR TITLE
Fix: Drop HHVM from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
         - php: 7.0
         - php: 7.1
           env: CHECKS=yes
-        - php: hhvm
 
 sudo: false
 


### PR DESCRIPTION
This PR

* [x] drops HHVM from the Travis build matrix

💁‍♂️ For reference, see https://travis-ci.org/satooshi/php-coveralls/jobs/259468321#L205:

> HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.

If you have a better suggestion, let me know, happy to help!