### PR TITLE
Fix: Remove useless return statements

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -186,7 +186,5 @@ class Jobs extends CoverallsApi
         if (isset($this->jsonFile)) {
             return $this->jsonFile;
         }
-
-        return;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -32,7 +32,7 @@ class Jobs extends CoverallsApi
     /**
      * JsonFile.
      *
-     * @var Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @var Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile|null
      */
     protected $jsonFile;
 
@@ -179,12 +179,10 @@ class Jobs extends CoverallsApi
     /**
      * Return JsonFile.
      *
-     * @return JsonFile
+     * @return JsonFile|null
      */
     public function getJsonFile()
     {
-        if (isset($this->jsonFile)) {
-            return $this->jsonFile;
-        }
+        return $this->jsonFile;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Commit.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Commit.php
@@ -98,8 +98,6 @@ class Commit extends Coveralls
         if (isset($this->id)) {
             return $this->id;
         }
-
-        return;
     }
 
     /**
@@ -126,8 +124,6 @@ class Commit extends Coveralls
         if (isset($this->authorName)) {
             return $this->authorName;
         }
-
-        return;
     }
 
     /**
@@ -154,8 +150,6 @@ class Commit extends Coveralls
         if (isset($this->authorEmail)) {
             return $this->authorEmail;
         }
-
-        return;
     }
 
     /**
@@ -182,8 +176,6 @@ class Commit extends Coveralls
         if (isset($this->committerName)) {
             return $this->committerName;
         }
-
-        return;
     }
 
     /**
@@ -210,8 +202,6 @@ class Commit extends Coveralls
         if (isset($this->committerEmail)) {
             return $this->committerEmail;
         }
-
-        return;
     }
 
     /**
@@ -238,7 +228,5 @@ class Commit extends Coveralls
         if (isset($this->message)) {
             return $this->message;
         }
-
-        return;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Commit.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Commit.php
@@ -14,42 +14,42 @@ class Commit extends Coveralls
     /**
      * Commit ID.
      *
-     * @var string
+     * @var string|null
      */
     protected $id;
 
     /**
      * Author name.
      *
-     * @var string
+     * @var string|null
      */
     protected $authorName;
 
     /**
      * Author email.
      *
-     * @var string
+     * @var string|null
      */
     protected $authorEmail;
 
     /**
      * Committer name.
      *
-     * @var string
+     * @var string|null
      */
     protected $committerName;
 
     /**
      * Committer email.
      *
-     * @var string
+     * @var string|null
      */
     protected $committerEmail;
 
     /**
      * Commit message.
      *
-     * @var string
+     * @var string|null
      */
     protected $message;
 
@@ -95,9 +95,7 @@ class Commit extends Coveralls
      */
     public function getId()
     {
-        if (isset($this->id)) {
-            return $this->id;
-        }
+        return $this->id;
     }
 
     /**
@@ -121,9 +119,7 @@ class Commit extends Coveralls
      */
     public function getAuthorName()
     {
-        if (isset($this->authorName)) {
-            return $this->authorName;
-        }
+        return $this->authorName;
     }
 
     /**
@@ -147,9 +143,7 @@ class Commit extends Coveralls
      */
     public function getAuthorEmail()
     {
-        if (isset($this->authorEmail)) {
-            return $this->authorEmail;
-        }
+        return $this->authorEmail;
     }
 
     /**
@@ -173,9 +167,7 @@ class Commit extends Coveralls
      */
     public function getCommitterName()
     {
-        if (isset($this->committerName)) {
-            return $this->committerName;
-        }
+        return $this->committerName;
     }
 
     /**
@@ -199,9 +191,7 @@ class Commit extends Coveralls
      */
     public function getCommitterEmail()
     {
-        if (isset($this->committerEmail)) {
-            return $this->committerEmail;
-        }
+        return $this->committerEmail;
     }
 
     /**
@@ -225,8 +215,6 @@ class Commit extends Coveralls
      */
     public function getMessage()
     {
-        if (isset($this->message)) {
-            return $this->message;
-        }
+        return $this->message;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
@@ -14,14 +14,14 @@ class Remote extends Coveralls
     /**
      * Remote name.
      *
-     * @var string
+     * @var string|null
      */
     protected $name;
 
     /**
      * Remote URL.
      *
-     * @var string
+     * @var string|null
      */
     protected $url;
 
@@ -59,13 +59,11 @@ class Remote extends Coveralls
     /**
      * Return remote name.
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
-        if (isset($this->name)) {
-            return $this->name;
-        }
+        return $this->name;
     }
 
     /**
@@ -85,12 +83,10 @@ class Remote extends Coveralls
     /**
      * Return remote URL.
      *
-     * @return string
+     * @return string|null
      */
     public function getUrl()
     {
-        if (isset($this->url)) {
-            return $this->url;
-        }
+        return $this->url;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
@@ -66,8 +66,6 @@ class Remote extends Coveralls
         if (isset($this->name)) {
             return $this->name;
         }
-
-        return;
     }
 
     /**
@@ -94,7 +92,5 @@ class Remote extends Coveralls
         if (isset($this->url)) {
             return $this->url;
         }
-
-        return;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
@@ -16,14 +16,14 @@ class JsonFile extends Coveralls
     /**
      * Service name.
      *
-     * @var string
+     * @var string|null
      */
     protected $serviceName;
 
     /**
      * Service job id.
      *
-     * @var string
+     * @var string|null
      */
     protected $serviceJobId;
 
@@ -65,7 +65,7 @@ class JsonFile extends Coveralls
     /**
      * Repository token.
      *
-     * @var string
+     * @var string|null
      */
     protected $repoToken;
 
@@ -79,7 +79,7 @@ class JsonFile extends Coveralls
     /**
      * Git data.
      *
-     * @var Git
+     * @var Git|null
      */
     protected $git;
 
@@ -88,7 +88,7 @@ class JsonFile extends Coveralls
      *
      * "2013-02-18 00:52:48 -0800"
      *
-     * @var string
+     * @var string|null
      */
     protected $runAt;
 
@@ -435,13 +435,11 @@ class JsonFile extends Coveralls
     /**
      * Return service name.
      *
-     * @return string
+     * @return string|null
      */
     public function getServiceName()
     {
-        if (isset($this->serviceName)) {
-            return $this->serviceName;
-        }
+        return $this->serviceName;
     }
 
     /**
@@ -461,13 +459,11 @@ class JsonFile extends Coveralls
     /**
      * Return repository token.
      *
-     * @return string
+     * @return string|null
      */
     public function getRepoToken()
     {
-        if (isset($this->repoToken)) {
-            return $this->repoToken;
-        }
+        return $this->repoToken;
     }
 
     /**
@@ -487,13 +483,11 @@ class JsonFile extends Coveralls
     /**
      * Return service job id.
      *
-     * @return string
+     * @return string|null
      */
     public function getServiceJobId()
     {
-        if (isset($this->serviceJobId)) {
-            return $this->serviceJobId;
-        }
+        return $this->serviceJobId;
     }
 
     /**
@@ -563,13 +557,11 @@ class JsonFile extends Coveralls
     /**
      * Return git data.
      *
-     * @return Git
+     * @return Git|null
      */
     public function getGit()
     {
-        if (isset($this->git)) {
-            return $this->git;
-        }
+        return $this->git;
     }
 
     /**
@@ -589,13 +581,11 @@ class JsonFile extends Coveralls
     /**
      * Return timestamp when the job ran.
      *
-     * @return string
+     * @return string|null
      */
     public function getRunAt()
     {
-        if (isset($this->runAt)) {
-            return $this->runAt;
-        }
+        return $this->runAt;
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
@@ -386,8 +386,6 @@ class JsonFile extends Coveralls
         if ($this->hasSourceFile($path)) {
             return $this->sourceFiles[$path];
         }
-
-        return;
     }
 
     /**
@@ -444,8 +442,6 @@ class JsonFile extends Coveralls
         if (isset($this->serviceName)) {
             return $this->serviceName;
         }
-
-        return;
     }
 
     /**
@@ -472,8 +468,6 @@ class JsonFile extends Coveralls
         if (isset($this->repoToken)) {
             return $this->repoToken;
         }
-
-        return;
     }
 
     /**
@@ -500,8 +494,6 @@ class JsonFile extends Coveralls
         if (isset($this->serviceJobId)) {
             return $this->serviceJobId;
         }
-
-        return;
     }
 
     /**
@@ -578,8 +570,6 @@ class JsonFile extends Coveralls
         if (isset($this->git)) {
             return $this->git;
         }
-
-        return;
     }
 
     /**
@@ -606,8 +596,6 @@ class JsonFile extends Coveralls
         if (isset($this->runAt)) {
             return $this->runAt;
         }
-
-        return;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] removes useless `return` statements
* [x] removes conditions and updates docblocks