### PR TITLE
Code grooming

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/CoverallsApi.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/CoverallsApi.php
@@ -15,7 +15,7 @@ abstract class CoverallsApi
     /**
      * Configuration.
      *
-     * @var Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @var Configuration
      */
     protected $config;
 
@@ -43,7 +43,7 @@ abstract class CoverallsApi
     /**
      * Return configuration.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return Configuration
      */
     public function getConfiguration()
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/CoverallsApi.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/CoverallsApi.php
@@ -55,7 +55,7 @@ abstract class CoverallsApi
      *
      * @param \GuzzleHttp\Client $client hTTP client
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Api\CoverallsApi
+     * @return $this
      */
     public function setHttpClient(Client $client)
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -41,7 +41,7 @@ class Jobs extends CoverallsApi
     /**
      * Collect clover XML into json_file.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs
+     * @return $this
      */
     public function collectCloverXml()
     {
@@ -69,7 +69,7 @@ class Jobs extends CoverallsApi
     /**
      * Collect git repository info into json_file.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs
+     * @return $this
      */
     public function collectGitInfo()
     {
@@ -88,7 +88,7 @@ class Jobs extends CoverallsApi
      *
      * @throws \Satooshi\Bundle\CoverallsV1Bundle\Entity\Exception\RequirementsNotSatisfiedException
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs
+     * @return $this
      */
     public function collectEnvVars(array $env)
     {
@@ -108,7 +108,7 @@ class Jobs extends CoverallsApi
     /**
      * Dump uploading json file.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs
+     * @return $this
      */
     public function dumpJsonFile()
     {
@@ -167,7 +167,7 @@ class Jobs extends CoverallsApi
      *
      * @param JsonFile $jsonFile json_file content
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs
+     * @return $this
      */
     public function setJsonFile(JsonFile $jsonFile)
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -186,7 +186,5 @@ class Jobs extends CoverallsApi
         if (isset($this->jsonFile)) {
             return $this->jsonFile;
         }
-
-        return;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -32,7 +32,7 @@ class Jobs extends CoverallsApi
     /**
      * JsonFile.
      *
-     * @var Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @var JsonFile
      */
     protected $jsonFile;
 

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Api/Jobs.php
@@ -179,12 +179,10 @@ class Jobs extends CoverallsApi
     /**
      * Return JsonFile.
      *
-     * @return JsonFile
+     * @return JsonFile|null
      */
     public function getJsonFile()
     {
-        if (isset($this->jsonFile)) {
-            return $this->jsonFile;
-        }
+        return $this->jsonFile;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CiEnvVarsCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CiEnvVarsCollector.php
@@ -75,7 +75,7 @@ class CiEnvVarsCollector
      *
      * "TRAVIS", "TRAVIS_JOB_ID" must be set.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Collector\CiEnvVarsCollector
+     * @return $this
      */
     protected function fillTravisCi()
     {
@@ -102,7 +102,7 @@ class CiEnvVarsCollector
      *
      * "CIRCLECI", "CIRCLE_BUILD_NUM" must be set.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Collector\CiEnvVarsCollector
+     * @return $this
      */
     protected function fillCircleCi()
     {
@@ -124,7 +124,7 @@ class CiEnvVarsCollector
      *
      * "JENKINS_URL", "BUILD_NUMBER" must be set.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Collector\CiEnvVarsCollector
+     * @return $this
      */
     protected function fillJenkins()
     {
@@ -147,7 +147,7 @@ class CiEnvVarsCollector
      *
      * "COVERALLS_RUN_LOCALLY" must be set.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Collector\CiEnvVarsCollector
+     * @return $this
      */
     protected function fillLocal()
     {
@@ -170,7 +170,7 @@ class CiEnvVarsCollector
      *
      * "COVERALLS_REPO_TOKEN" must be set.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Collector\CiEnvVarsCollector
+     * @return $this
      */
     protected function fillRepoToken()
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CiEnvVarsCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CiEnvVarsCollector.php
@@ -58,11 +58,12 @@ class CiEnvVarsCollector
         $this->env = $env;
         $this->readEnv = [];
 
-        $this->fillTravisCi()
-        ->fillCircleCi()
-        ->fillJenkins()
-        ->fillLocal()
-        ->fillRepoToken();
+        $this
+            ->fillTravisCi()
+            ->fillCircleCi()
+            ->fillJenkins()
+            ->fillLocal()
+            ->fillRepoToken();
 
         return $this->env;
     }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CiEnvVarsCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CiEnvVarsCollector.php
@@ -14,7 +14,7 @@ class CiEnvVarsCollector
     /**
      * Configuration.
      *
-     * @var Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @var Configuration
      */
     protected $config;
 

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
@@ -93,10 +93,10 @@ class CloverXmlCoverageCollector
             return;
         }
 
+        $filename = $absolutePath;
+
         if ($root !== DIRECTORY_SEPARATOR) {
             $filename = str_replace($root, '', $absolutePath);
-        } else {
-            $filename = $absolutePath;
         }
 
         return $this->collectCoverage($file, $absolutePath, $filename);

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
@@ -33,7 +33,7 @@ class CloverXmlCoverageCollector
     {
         $root = rtrim($rootDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
-        if (!isset($this->jsonFile)) {
+        if ($this->jsonFile === null) {
             $this->jsonFile = new JsonFile();
         }
 

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollector.php
@@ -89,12 +89,12 @@ class GitInfoCollector
         $commit = new Commit();
 
         return $commit
-        ->setId($commitResult[0])
-        ->setAuthorName($commitResult[1])
-        ->setAuthorEmail($commitResult[2])
-        ->setCommitterName($commitResult[3])
-        ->setCommitterEmail($commitResult[4])
-        ->setMessage($commitResult[5]);
+            ->setId($commitResult[0])
+            ->setAuthorName($commitResult[1])
+            ->setAuthorEmail($commitResult[2])
+            ->setCommitterName($commitResult[3])
+            ->setCommitterEmail($commitResult[4])
+            ->setMessage($commitResult[5]);
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommand.php
@@ -47,48 +47,48 @@ class CoverallsV1JobsCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('coveralls:v1:jobs')
-        ->setDescription('Coveralls Jobs API v1')
-        ->addOption(
-            'config',
-            '-c',
-            InputOption::VALUE_OPTIONAL,
-            '.coveralls.yml path',
-            '.coveralls.yml'
-        )
-        ->addOption(
-            'dry-run',
-            null,
-            InputOption::VALUE_NONE,
-            'Do not send json_file to Jobs API'
-        )
-        ->addOption(
-            'exclude-no-stmt',
-            null,
-            InputOption::VALUE_NONE,
-            'Exclude source files that have no executable statements'
-        )
-        ->addOption(
-            'env',
-            '-e',
-            InputOption::VALUE_OPTIONAL,
-            'Runtime environment name: test, dev, prod',
-            'prod'
-        )
-        ->addOption(
-            'coverage_clover',
-            '-x',
-            InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-            'Coverage clover xml files(allowing multiple values).',
-            []
-        )
-        ->addOption(
-            'root_dir',
-            '-r',
-            InputOption::VALUE_OPTIONAL,
-            'Root directory of the project.',
-            '.'
-        );
+            ->setName('coveralls:v1:jobs')
+            ->setDescription('Coveralls Jobs API v1')
+            ->addOption(
+                'config',
+                '-c',
+                InputOption::VALUE_OPTIONAL,
+                '.coveralls.yml path',
+                '.coveralls.yml'
+            )
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not send json_file to Jobs API'
+            )
+            ->addOption(
+                'exclude-no-stmt',
+                null,
+                InputOption::VALUE_NONE,
+                'Exclude source files that have no executable statements'
+            )
+            ->addOption(
+                'env',
+                '-e',
+                InputOption::VALUE_OPTIONAL,
+                'Runtime environment name: test, dev, prod',
+                'prod'
+            )
+            ->addOption(
+                'coverage_clover',
+                '-x',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Coverage clover xml files(allowing multiple values).',
+                []
+            )
+            ->addOption(
+                'root_dir',
+                '-r',
+                InputOption::VALUE_OPTIONAL,
+                'Root directory of the project.',
+                '.'
+            );
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configuration.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configuration.php
@@ -101,7 +101,7 @@ class Configuration
      */
     public function hasRepoToken()
     {
-        return isset($this->repoToken);
+        return $this->repoToken !== null;
     }
 
     /**
@@ -135,7 +135,7 @@ class Configuration
      */
     public function hasServiceName()
     {
-        return isset($this->serviceName);
+        return $this->serviceName !== null;
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configuration.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configuration.php
@@ -85,7 +85,7 @@ class Configuration
      *
      * @param string $repoToken
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setRepoToken($repoToken)
     {
@@ -119,7 +119,7 @@ class Configuration
      *
      * @param string $serviceName
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setServiceName($serviceName)
     {
@@ -165,7 +165,7 @@ class Configuration
      *
      * @param string[] $cloverXmlPaths
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setCloverXmlPaths(array $cloverXmlPaths)
     {
@@ -179,7 +179,7 @@ class Configuration
      *
      * @param string $cloverXmlPath
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function addCloverXmlPath($cloverXmlPath)
     {
@@ -203,7 +203,7 @@ class Configuration
      *
      * @param string $jsonPath
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setJsonPath($jsonPath)
     {
@@ -227,7 +227,7 @@ class Configuration
      *
      * @param bool $dryRun
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setDryRun($dryRun)
     {
@@ -251,7 +251,7 @@ class Configuration
      *
      * @param bool $excludeNoStatements
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setExcludeNoStatements($excludeNoStatements)
     {
@@ -265,7 +265,7 @@ class Configuration
      *
      * @param bool $excludeNoStatements
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setExcludeNoStatementsUnlessFalse($excludeNoStatements)
     {
@@ -291,7 +291,7 @@ class Configuration
      *
      * @param bool $verbose
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setVerbose($verbose)
     {
@@ -315,7 +315,7 @@ class Configuration
      *
      * @param string $env runtime environment name
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration
+     * @return $this
      */
     public function setEnv($env)
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -119,7 +119,7 @@ class Configurator
      *
      * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      *
-     * @return array valid Absolute pathes of coverage_clover
+     * @return string[] valid Absolute pathes of coverage_clover
      */
     protected function ensureCloverXmlPaths($option, $rootDir, Path $file)
     {
@@ -137,7 +137,7 @@ class Configurator
      *
      * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      *
-     * @return array absolute paths
+     * @return string[] absolute paths
      */
     protected function getGlobPaths($path)
     {
@@ -166,7 +166,7 @@ class Configurator
      *
      * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      *
-     * @return array absolute pathes
+     * @return string[] absolute pathes
      */
     protected function getGlobPathsFromStringOption($option, $rootDir, Path $file)
     {
@@ -189,7 +189,7 @@ class Configurator
      *
      * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      *
-     * @return array absolute pathes
+     * @return string[] absolute pathes
      */
     protected function getGlobPathsFromArrayOption(array $options, $rootDir, Path $file)
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -102,12 +102,12 @@ class Configurator
         }
 
         return $configuration
-        ->setRepoToken($repoToken !== null ? $repoToken : $repoSecretToken)
-        ->setServiceName($options['service_name'])
-        ->setRootDir($rootDir)
-        ->setCloverXmlPaths($this->ensureCloverXmlPaths($coverage_clover, $rootDir, $file))
-        ->setJsonPath($this->ensureJsonPath($options['json_path'], $rootDir, $file))
-        ->setExcludeNoStatements($options['exclude_no_stmt']);
+            ->setRepoToken($repoToken !== null ? $repoToken : $repoSecretToken)
+            ->setServiceName($options['service_name'])
+            ->setRootDir($rootDir)
+            ->setCloverXmlPaths($this->ensureCloverXmlPaths($coverage_clover, $rootDir, $file))
+            ->setJsonPath($this->ensureJsonPath($options['json_path'], $rootDir, $file))
+            ->setExcludeNoStatements($options['exclude_no_stmt']);
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Config/Configurator.php
@@ -119,7 +119,7 @@ class Configurator
      *
      * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      *
-     * @return string[] valid Absolute pathes of coverage_clover
+     * @return string[] valid Absolute paths of coverage_clover
      */
     protected function ensureCloverXmlPaths($option, $rootDir, Path $file)
     {
@@ -166,7 +166,7 @@ class Configurator
      *
      * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      *
-     * @return string[] absolute pathes
+     * @return string[] absolute paths
      */
     protected function getGlobPathsFromStringOption($option, $rootDir, Path $file)
     {
@@ -189,7 +189,7 @@ class Configurator
      *
      * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      *
-     * @return string[] absolute pathes
+     * @return string[] absolute paths
      */
     protected function getGlobPathsFromArrayOption(array $options, $rootDir, Path $file)
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Exception/RequirementsNotSatisfiedException.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Exception/RequirementsNotSatisfiedException.php
@@ -60,7 +60,7 @@ class RequirementsNotSatisfiedException extends \RuntimeException
     {
         $message = $this->message . "\n";
 
-        if (isset($this->readEnv) && is_array($this->readEnv)) {
+        if (is_array($this->readEnv)) {
             foreach ($this->readEnv as $envVarName => $value) {
                 $message .= $this->format($envVarName, $value);
             }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Commit.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Commit.php
@@ -98,8 +98,6 @@ class Commit extends Coveralls
         if (isset($this->id)) {
             return $this->id;
         }
-
-        return;
     }
 
     /**
@@ -126,8 +124,6 @@ class Commit extends Coveralls
         if (isset($this->authorName)) {
             return $this->authorName;
         }
-
-        return;
     }
 
     /**
@@ -154,8 +150,6 @@ class Commit extends Coveralls
         if (isset($this->authorEmail)) {
             return $this->authorEmail;
         }
-
-        return;
     }
 
     /**
@@ -182,8 +176,6 @@ class Commit extends Coveralls
         if (isset($this->committerName)) {
             return $this->committerName;
         }
-
-        return;
     }
 
     /**
@@ -210,8 +202,6 @@ class Commit extends Coveralls
         if (isset($this->committerEmail)) {
             return $this->committerEmail;
         }
-
-        return;
     }
 
     /**
@@ -238,7 +228,5 @@ class Commit extends Coveralls
         if (isset($this->message)) {
             return $this->message;
         }
-
-        return;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Commit.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Commit.php
@@ -14,42 +14,42 @@ class Commit extends Coveralls
     /**
      * Commit ID.
      *
-     * @var string
+     * @var string|null
      */
     protected $id;
 
     /**
      * Author name.
      *
-     * @var string
+     * @var string|null
      */
     protected $authorName;
 
     /**
      * Author email.
      *
-     * @var string
+     * @var string|null
      */
     protected $authorEmail;
 
     /**
      * Committer name.
      *
-     * @var string
+     * @var string|null
      */
     protected $committerName;
 
     /**
      * Committer email.
      *
-     * @var string
+     * @var string|null
      */
     protected $committerEmail;
 
     /**
      * Commit message.
      *
-     * @var string
+     * @var string|null
      */
     protected $message;
 
@@ -95,9 +95,7 @@ class Commit extends Coveralls
      */
     public function getId()
     {
-        if (isset($this->id)) {
-            return $this->id;
-        }
+        return $this->id;
     }
 
     /**
@@ -121,9 +119,7 @@ class Commit extends Coveralls
      */
     public function getAuthorName()
     {
-        if (isset($this->authorName)) {
-            return $this->authorName;
-        }
+        return $this->authorName;
     }
 
     /**
@@ -147,9 +143,7 @@ class Commit extends Coveralls
      */
     public function getAuthorEmail()
     {
-        if (isset($this->authorEmail)) {
-            return $this->authorEmail;
-        }
+        return $this->authorEmail;
     }
 
     /**
@@ -173,9 +167,7 @@ class Commit extends Coveralls
      */
     public function getCommitterName()
     {
-        if (isset($this->committerName)) {
-            return $this->committerName;
-        }
+        return $this->committerName;
     }
 
     /**
@@ -199,9 +191,7 @@ class Commit extends Coveralls
      */
     public function getCommitterEmail()
     {
-        if (isset($this->committerEmail)) {
-            return $this->committerEmail;
-        }
+        return $this->committerEmail;
     }
 
     /**
@@ -225,8 +215,6 @@ class Commit extends Coveralls
      */
     public function getMessage()
     {
-        if (isset($this->message)) {
-            return $this->message;
-        }
+        return $this->message;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
@@ -14,14 +14,14 @@ class Remote extends Coveralls
     /**
      * Remote name.
      *
-     * @var string
+     * @var string|null
      */
     protected $name;
 
     /**
      * Remote URL.
      *
-     * @var string
+     * @var string|null
      */
     protected $url;
 
@@ -59,13 +59,11 @@ class Remote extends Coveralls
     /**
      * Return remote name.
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
-        if (isset($this->name)) {
-            return $this->name;
-        }
+        return $this->name;
     }
 
     /**
@@ -85,12 +83,10 @@ class Remote extends Coveralls
     /**
      * Return remote URL.
      *
-     * @return string
+     * @return string|null
      */
     public function getUrl()
     {
-        if (isset($this->url)) {
-            return $this->url;
-        }
+        return $this->url;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
@@ -47,7 +47,7 @@ class Remote extends Coveralls
      *
      * @param string $name remote name
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\Git\Remote
+     * @return $this
      */
     public function setName($name)
     {
@@ -71,7 +71,7 @@ class Remote extends Coveralls
      *
      * @param string $url remote URL
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\Git\Remote
+     * @return $this
      */
     public function setUrl($url)
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/Remote.php
@@ -66,8 +66,6 @@ class Remote extends Coveralls
         if (isset($this->name)) {
             return $this->name;
         }
-
-        return;
     }
 
     /**
@@ -94,7 +92,5 @@ class Remote extends Coveralls
         if (isset($this->url)) {
             return $this->url;
         }
-
-        return;
     }
 }

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
@@ -388,8 +388,6 @@ class JsonFile extends Coveralls
         if ($this->hasSourceFile($path)) {
             return $this->sourceFiles[$path];
         }
-
-        return;
     }
 
     /**
@@ -446,8 +444,6 @@ class JsonFile extends Coveralls
         if (isset($this->serviceName)) {
             return $this->serviceName;
         }
-
-        return;
     }
 
     /**
@@ -474,8 +470,6 @@ class JsonFile extends Coveralls
         if (isset($this->repoToken)) {
             return $this->repoToken;
         }
-
-        return;
     }
 
     /**
@@ -502,8 +496,6 @@ class JsonFile extends Coveralls
         if (isset($this->serviceJobId)) {
             return $this->serviceJobId;
         }
-
-        return;
     }
 
     /**
@@ -580,8 +572,6 @@ class JsonFile extends Coveralls
         if (isset($this->git)) {
             return $this->git;
         }
-
-        return;
     }
 
     /**
@@ -608,8 +598,6 @@ class JsonFile extends Coveralls
         if (isset($this->runAt)) {
             return $this->runAt;
         }
-
-        return;
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
@@ -150,8 +150,8 @@ class JsonFile extends Coveralls
     public function fillJobs(array $env)
     {
         return $this
-        ->fillStandardizedEnvVars($env)
-        ->ensureJobs();
+            ->fillStandardizedEnvVars($env)
+            ->ensureJobs();
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
@@ -16,14 +16,14 @@ class JsonFile extends Coveralls
     /**
      * Service name.
      *
-     * @var string
+     * @var string|null
      */
     protected $serviceName;
 
     /**
      * Service job id.
      *
-     * @var string
+     * @var string|null
      */
     protected $serviceJobId;
 
@@ -65,7 +65,7 @@ class JsonFile extends Coveralls
     /**
      * Repository token.
      *
-     * @var string
+     * @var string|null
      */
     protected $repoToken;
 
@@ -79,7 +79,7 @@ class JsonFile extends Coveralls
     /**
      * Git data.
      *
-     * @var Git
+     * @var Git|null
      */
     protected $git;
 
@@ -88,7 +88,7 @@ class JsonFile extends Coveralls
      *
      * "2013-02-18 00:52:48 -0800"
      *
-     * @var string
+     * @var string|null
      */
     protected $runAt;
 
@@ -437,13 +437,11 @@ class JsonFile extends Coveralls
     /**
      * Return service name.
      *
-     * @return string
+     * @return string|null
      */
     public function getServiceName()
     {
-        if (isset($this->serviceName)) {
-            return $this->serviceName;
-        }
+        return $this->serviceName;
     }
 
     /**
@@ -463,13 +461,11 @@ class JsonFile extends Coveralls
     /**
      * Return repository token.
      *
-     * @return string
+     * @return string|null
      */
     public function getRepoToken()
     {
-        if (isset($this->repoToken)) {
-            return $this->repoToken;
-        }
+        return $this->repoToken;
     }
 
     /**
@@ -489,13 +485,11 @@ class JsonFile extends Coveralls
     /**
      * Return service job id.
      *
-     * @return string
+     * @return string|null
      */
     public function getServiceJobId()
     {
-        if (isset($this->serviceJobId)) {
-            return $this->serviceJobId;
-        }
+        return $this->serviceJobId;
     }
 
     /**
@@ -565,13 +559,11 @@ class JsonFile extends Coveralls
     /**
      * Return git data.
      *
-     * @return Git
+     * @return Git|null
      */
     public function getGit()
     {
-        if (isset($this->git)) {
-            return $this->git;
-        }
+        return $this->git;
     }
 
     /**
@@ -591,13 +583,11 @@ class JsonFile extends Coveralls
     /**
      * Return timestamp when the job ran.
      *
-     * @return string
+     * @return string|null
      */
     public function getRunAt()
     {
-        if (isset($this->runAt)) {
-            return $this->runAt;
-        }
+        return $this->runAt;
     }
 
     /**

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
@@ -205,7 +205,9 @@ class JsonFile extends Coveralls
     {
         if ($prop instanceof Coveralls) {
             return $prop->toArray();
-        } elseif (is_array($prop)) {
+        }
+
+        if (is_array($prop)) {
             return $this->toJsonPropertyArray($prop);
         }
 

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
@@ -145,7 +145,7 @@ class JsonFile extends Coveralls
      *
      * @throws \RuntimeException
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @return $this
      */
     public function fillJobs(array $env)
     {
@@ -249,7 +249,7 @@ class JsonFile extends Coveralls
      *
      * @param array $env $_SERVER environment
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @return $this
      */
     protected function fillStandardizedEnvVars(array $env)
     {
@@ -281,7 +281,7 @@ class JsonFile extends Coveralls
      *
      * @throws \RuntimeException
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @return $this
      */
     protected function ensureJobs()
     {
@@ -425,7 +425,7 @@ class JsonFile extends Coveralls
      *
      * @param string $serviceName service name
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @return $this
      */
     public function setServiceName($serviceName)
     {
@@ -449,7 +449,7 @@ class JsonFile extends Coveralls
      *
      * @param string $repoToken repository token
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @return $this
      */
     public function setRepoToken($repoToken)
     {
@@ -473,7 +473,7 @@ class JsonFile extends Coveralls
      *
      * @param string $serviceJobId service job id
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @return $this
      */
     public function setServiceJobId($serviceJobId)
     {
@@ -547,7 +547,7 @@ class JsonFile extends Coveralls
      *
      * @param Git $git git data
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @return $this
      */
     public function setGit(Git $git)
     {
@@ -571,7 +571,7 @@ class JsonFile extends Coveralls
      *
      * @param string $runAt timestamp
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile
+     * @return $this
      */
     public function setRunAt($runAt)
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/JsonFile.php
@@ -317,7 +317,7 @@ class JsonFile extends Coveralls
      */
     protected function requireServiceJobId()
     {
-        return isset($this->serviceName) && isset($this->serviceJobId) && !isset($this->repoToken);
+        return $this->serviceName !== null && $this->serviceJobId !== null && $this->repoToken === null;
     }
 
     /**
@@ -327,7 +327,7 @@ class JsonFile extends Coveralls
      */
     protected function requireServiceNumber()
     {
-        return isset($this->serviceName) && isset($this->serviceNumber) && isset($this->repoToken);
+        return $this->serviceName !== null && $this->serviceNumber !== null && $this->repoToken !== null;
     }
 
     /**
@@ -337,7 +337,7 @@ class JsonFile extends Coveralls
      */
     protected function requireServiceEventType()
     {
-        return isset($this->serviceName) && isset($this->serviceEventType) && isset($this->repoToken);
+        return $this->serviceName !== null && $this->serviceEventType !== null && $this->repoToken !== null;
     }
 
     /**
@@ -347,7 +347,7 @@ class JsonFile extends Coveralls
      */
     protected function requireRepoToken()
     {
-        return isset($this->serviceName) && $this->serviceName === 'travis-pro' && isset($this->repoToken);
+        return $this->serviceName === 'travis-pro' && $this->repoToken !== null;
     }
 
     /**
@@ -357,7 +357,7 @@ class JsonFile extends Coveralls
      */
     protected function isUnsupportedServiceJob()
     {
-        return !isset($this->serviceJobId) && !isset($this->serviceNumber) && !isset($this->serviceEventType) && isset($this->repoToken);
+        return $this->serviceJobId === null && $this->serviceNumber === null && $this->serviceEventType === null && $this->repoToken !== null;
     }
 
     // accessor
@@ -617,7 +617,7 @@ class JsonFile extends Coveralls
      */
     public function getMetrics()
     {
-        if (!isset($this->metrics)) {
+        if ($this->metrics === null) {
             $this->metrics = new Metrics();
         }
 

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Metrics.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Metrics.php
@@ -14,14 +14,14 @@ class Metrics
      *
      * @var int
      */
-    protected $statements;
+    protected $statements = 0;
 
     /**
      * Number of covered statements.
      *
      * @var int
      */
-    protected $coveredStatements;
+    protected $coveredStatements = 0;
 
     /**
      * Line coverage.
@@ -37,30 +37,25 @@ class Metrics
      */
     public function __construct(array $coverage = [])
     {
-        if (!empty($coverage)) {
-            // statements
-            // not null
-            $statementsArray = array_filter(
-                $coverage,
-                function ($line) {
-                    return $line !== null;
-                }
-            );
-            $this->statements = count($statementsArray);
+        // statements
+        // not null
+        $statementsArray = array_filter(
+            $coverage,
+            function ($line) {
+                return $line !== null;
+            }
+        );
+        $this->statements = count($statementsArray);
 
-            // covered statements
-            // gt 0
-            $coveredArray = array_filter(
-                $statementsArray,
-                function ($line) {
-                    return $line > 0;
-                }
-            );
-            $this->coveredStatements = count($coveredArray);
-        } else {
-            $this->statements = 0;
-            $this->coveredStatements = 0;
-        }
+        // covered statements
+        // gt 0
+        $coveredArray = array_filter(
+            $statementsArray,
+            function ($line) {
+                return $line > 0;
+            }
+        );
+        $this->coveredStatements = count($coveredArray);
     }
 
     // API

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Metrics.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Metrics.php
@@ -135,7 +135,7 @@ class Metrics
      */
     public function getLineCoverage()
     {
-        if (!isset($this->lineCoverage)) {
+        if ($this->lineCoverage === null) {
             $this->lineCoverage = $this->calculateLineCoverage($this->statements, $this->coveredStatements);
         }
 

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Metrics.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/Metrics.php
@@ -48,7 +48,7 @@ class Metrics
             );
             $this->statements = count($statementsArray);
 
-            // coveredstatements
+            // covered statements
             // gt 0
             $coveredArray = array_filter(
                 $statementsArray,

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/SourceFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/SourceFile.php
@@ -167,7 +167,7 @@ class SourceFile extends Coveralls
      */
     public function getMetrics()
     {
-        if (!isset($this->metrics)) {
+        if ($this->metrics === null) {
             $this->metrics = new Metrics($this->coverage);
         }
 

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/SourceFile.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Entity/SourceFile.php
@@ -163,7 +163,7 @@ class SourceFile extends Coveralls
     /**
      * Return metrics.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Entity\Metrics
+     * @return Metrics
      */
     public function getMetrics()
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
@@ -77,7 +77,7 @@ class JobsRepository implements LoggerAwareInterface
     /**
      * Collect clover XML into json_file.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Repository\JobsRepository
+     * @return $this
      */
     protected function collectCloverXml()
     {
@@ -99,7 +99,7 @@ class JobsRepository implements LoggerAwareInterface
     /**
      * Collect git repository info into json_file.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Repository\JobsRepository
+     * @return $this
      */
     protected function collectGitInfo()
     {
@@ -113,7 +113,7 @@ class JobsRepository implements LoggerAwareInterface
     /**
      * Collect environment variables.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Repository\JobsRepository
+     * @return $this
      */
     protected function collectEnvVars()
     {
@@ -127,7 +127,7 @@ class JobsRepository implements LoggerAwareInterface
     /**
      * Dump submitting json file.
      *
-     * @return \Satooshi\Bundle\CoverallsV1Bundle\Repository\JobsRepository
+     * @return $this
      */
     protected function dumpJsonFile()
     {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
@@ -2,7 +2,6 @@
 
 namespace Satooshi\Bundle\CoverallsV1Bundle\Repository;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
@@ -60,11 +60,11 @@ class JobsRepository implements LoggerAwareInterface
     {
         try {
             $this
-            ->collectCloverXml()
-            ->collectGitInfo()
-            ->collectEnvVars()
-            ->dumpJsonFile()
-            ->send();
+                ->collectCloverXml()
+                ->collectGitInfo()
+                ->collectEnvVars()
+                ->dumpJsonFile()
+                ->send();
         } catch (\Satooshi\Bundle\CoverallsV1Bundle\Entity\Exception\RequirementsNotSatisfiedException $e) {
             $this->logger->error(sprintf('%s', $e->getHelpMessage()));
         } catch (\Exception $e) {

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepository.php
@@ -203,7 +203,9 @@ class JobsRepository implements LoggerAwareInterface
     {
         if ($coverage >= 90) {
             return sprintf('<info>%s</info>', $format);
-        } elseif ($coverage >= 80) {
+        }
+
+        if ($coverage >= 80) {
             return sprintf('<comment>%s</comment>', $format);
         }
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
@@ -2,6 +2,8 @@
 
 namespace Satooshi\Bundle\CoverallsV1Bundle\Api;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7;
 use Satooshi\Bundle\CoverallsV1Bundle\Collector\CiEnvVarsCollector;
 use Satooshi\Bundle\CoverallsV1Bundle\Collector\CloverXmlCoverageCollector;
 use Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration;
@@ -70,7 +72,7 @@ class JobsTest extends ProjectTestCase
 
     protected function createAdapterMockNeverCalled()
     {
-        $client = $this->prophesize('\GuzzleHttp\Client');
+        $client = $this->prophesize(Client::class);
         $client
             ->send()
             ->shouldNotBeCalled();
@@ -80,10 +82,10 @@ class JobsTest extends ProjectTestCase
 
     protected function createAdapterMockWith($url, $filename, $jsonPath)
     {
-        $response = $this->prophesize('\GuzzleHttp\Psr7\Response');
+        $response = $this->prophesize(Psr7\Response::class);
         $response->reveal();
 
-        $client = $this->prophesize('\GuzzleHttp\Client');
+        $client = $this->prophesize(Client::class);
         $client
             ->post($url, \Prophecy\Argument::that(function ($options) use ($filename) {
                 return !empty($options['multipart'][0]['name'])

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
@@ -38,8 +38,8 @@ class JobsTest extends ProjectTestCase
         $this->config = new Configuration();
 
         $this->config
-        ->setJsonPath($this->jsonPath)
-        ->setDryRun(false);
+            ->setJsonPath($this->jsonPath)
+            ->setDryRun(false);
 
         $this->client = $this->createAdapterMockWith($this->url, $this->filename);
 
@@ -50,8 +50,8 @@ class JobsTest extends ProjectTestCase
     {
         $this->config = new Configuration();
         $this->config
-        ->setJsonPath($this->jsonPath)
-        ->setDryRun(false);
+            ->setJsonPath($this->jsonPath)
+            ->setDryRun(false);
 
         $this->client = $this->createAdapterMockNeverCalled();
 
@@ -62,8 +62,8 @@ class JobsTest extends ProjectTestCase
     {
         $this->config = new Configuration();
         $this->config
-        ->setJsonPath($this->jsonPath)
-        ->setDryRun(true);
+            ->setJsonPath($this->jsonPath)
+            ->setDryRun(true);
 
         $this->client = $this->createAdapterMockNeverCalled();
 
@@ -103,8 +103,7 @@ class JobsTest extends ProjectTestCase
     {
         $config = new Configuration();
 
-        return $config
-        ->addCloverXmlPath($this->cloverXmlPath);
+        return $config->addCloverXmlPath($this->cloverXmlPath);
     }
 
     protected function getCloverXml()
@@ -441,10 +440,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 
     /**
@@ -468,10 +467,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
 
         $this->assertSame($serviceName, $jsonFile->getServiceName());
         $this->assertSame($serviceJobId, $jsonFile->getServiceJobId());
@@ -497,10 +496,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 
     /**
@@ -522,10 +521,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 
     /**
@@ -543,10 +542,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 
     /**
@@ -563,10 +562,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 
     /**
@@ -584,10 +583,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 
     /**
@@ -606,10 +605,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 
     /**
@@ -624,10 +623,10 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 
     /**
@@ -646,9 +645,9 @@ XML;
         $jsonFile = $this->collectJsonFile();
 
         $object
-        ->setJsonFile($jsonFile)
-        ->collectEnvVars($server)
-        ->dumpJsonFile()
-        ->send();
+            ->setJsonFile($jsonFile)
+            ->collectEnvVars($server)
+            ->dumpJsonFile()
+            ->send();
     }
 }

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
@@ -431,7 +431,6 @@ XML;
     {
         $this->makeProjectDir(null, $this->logsDir);
 
-        $serviceName = 'travis-ci';
         $serviceJobId = '1.1';
 
         $server = [];
@@ -465,7 +464,7 @@ XML;
         $server['COVERALLS_REPO_TOKEN'] = $repoToken;
 
         $object = $this->createJobsWith();
-        $config = $object->getConfiguration()->setServiceName($serviceName);
+        $object->getConfiguration()->setServiceName($serviceName);
         $jsonFile = $this->collectJsonFile();
 
         $object
@@ -486,7 +485,6 @@ XML;
     {
         $this->makeProjectDir(null, $this->logsDir);
 
-        $serviceName = 'circleci';
         $serviceNumber = '123';
         $repoToken = 'token';
 
@@ -512,7 +510,6 @@ XML;
     {
         $this->makeProjectDir(null, $this->logsDir);
 
-        $serviceName = 'jenkins';
         $serviceNumber = '123';
         $repoToken = 'token';
 
@@ -538,14 +535,11 @@ XML;
     {
         $this->makeProjectDir(null, $this->logsDir);
 
-        $serviceName = 'php-coveralls';
-        $serviceEventType = 'manual';
-
         $server = [];
         $server['COVERALLS_RUN_LOCALLY'] = '1';
 
         $object = $this->createJobsWith();
-        $config = $object->getConfiguration()->setRepoToken('token');
+        $object->getConfiguration()->setRepoToken('token');
         $jsonFile = $this->collectJsonFile();
 
         $object
@@ -608,7 +602,7 @@ XML;
         $server['TRAVIS_JOB_ID'] = '1.1';
 
         $object = $this->createJobsNeverSendOnDryRun();
-        $config = $object->getConfiguration()->setEnv('test');
+        $object->getConfiguration()->setEnv('test');
         $jsonFile = $this->collectJsonFile();
 
         $object

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Api/JobsTest.php
@@ -41,7 +41,7 @@ class JobsTest extends ProjectTestCase
         ->setJsonPath($this->jsonPath)
         ->setDryRun(false);
 
-        $this->client = $this->createAdapterMockWith($this->url, $this->filename, $this->jsonPath);
+        $this->client = $this->createAdapterMockWith($this->url, $this->filename);
 
         return new Jobs($this->config, $this->client);
     }
@@ -80,7 +80,7 @@ class JobsTest extends ProjectTestCase
         return $client->reveal();
     }
 
-    protected function createAdapterMockWith($url, $filename, $jsonPath)
+    protected function createAdapterMockWith($url, $filename)
     {
         $response = $this->prophesize(Psr7\Response::class);
         $response->reveal();

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
@@ -46,13 +46,13 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
         return $stub->reveal();
     }
 
-    protected function createGitCommandStubCalledBranches($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
+    protected function createGitCommandStubCalledBranches($getBranchesValue)
     {
         $stub = $this->prophesize(GitCommand::class);
 
         $this->setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue);
-        $this->setUpGitCommandStubWithGetHeadCommitNeverCalled($stub, $getHeadCommitValue);
-        $this->setUpGitCommandStubWithGetRemotesNeverCalled($stub, $getRemotesValue);
+        $this->setUpGitCommandStubWithGetHeadCommitNeverCalled($stub);
+        $this->setUpGitCommandStubWithGetRemotesNeverCalled($stub);
 
         return $stub->reveal();
     }
@@ -63,7 +63,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
 
         $this->setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue);
         $this->setUpGitCommandStubWithGetHeadCommitOnce($stub, $getHeadCommitValue);
-        $this->setUpGitCommandStubWithGetRemotesNeverCalled($stub, $getRemotesValue);
+        $this->setUpGitCommandStubWithGetRemotesNeverCalled($stub);
 
         return $stub->reveal();
     }
@@ -84,7 +84,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalled();
     }
 
-    protected function setUpGitCommandStubWithGetHeadCommitNeverCalled($stub, $getHeadCommitValue)
+    protected function setUpGitCommandStubWithGetHeadCommitNeverCalled($stub)
     {
         $stub
             ->getHeadCommit()
@@ -99,7 +99,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalled();
     }
 
-    protected function setUpGitCommandStubWithGetRemotesNeverCalled($stub, $getRemotesValue)
+    protected function setUpGitCommandStubWithGetRemotesNeverCalled($stub)
     {
         $stub
             ->getRemotes()
@@ -178,7 +178,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
         $getBranchesValue = [
             '  master',
         ];
-        $gitCommand = $this->createGitCommandStubCalledBranches($getBranchesValue, $this->getHeadCommitValue, $this->getRemotesValue);
+        $gitCommand = $this->createGitCommandStubCalledBranches($getBranchesValue);
 
         $object = new GitInfoCollector($gitCommand);
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
@@ -131,8 +131,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
 
         $git = $object->collect();
 
-        $gitClass = Git::class;
-        $this->assertTrue($git instanceof $gitClass);
+        $this->assertInstanceOf(Git::class, $git);
         $this->assertGit($git);
     }
 
@@ -142,15 +141,13 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
 
         $commit = $git->getHead();
 
-        $commitClass = Commit::class;
-        $this->assertTrue($commit instanceof $commitClass);
+        $this->assertInstanceOf(Commit::class, $commit);
         $this->assertCommit($commit);
 
         $remotes = $git->getRemotes();
         $this->assertCount(1, $remotes);
 
-        $remoteClass = Remote::class;
-        $this->assertTrue($remotes[0] instanceof $remoteClass);
+        $this->assertInstanceOf(Remote::class, $remotes[0]);
         $this->assertRemote($remotes[0]);
     }
 

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/GitInfoCollectorTest.php
@@ -37,7 +37,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
 
     protected function createGitCommandStubWith($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
     {
-        $stub = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
+        $stub = $this->prophesize(GitCommand::class);
 
         $this->setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue);
         $this->setUpGitCommandStubWithGetHeadCommitOnce($stub, $getHeadCommitValue);
@@ -48,7 +48,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
 
     protected function createGitCommandStubCalledBranches($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
     {
-        $stub = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
+        $stub = $this->prophesize(GitCommand::class);
 
         $this->setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue);
         $this->setUpGitCommandStubWithGetHeadCommitNeverCalled($stub, $getHeadCommitValue);
@@ -59,7 +59,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
 
     protected function createGitCommandStubCalledHeadCommit($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
     {
-        $stub = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
+        $stub = $this->prophesize(GitCommand::class);
 
         $this->setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue);
         $this->setUpGitCommandStubWithGetHeadCommitOnce($stub, $getHeadCommitValue);
@@ -131,7 +131,7 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
 
         $git = $object->collect();
 
-        $gitClass = 'Satooshi\Bundle\CoverallsV1Bundle\Entity\Git\Git';
+        $gitClass = Git::class;
         $this->assertTrue($git instanceof $gitClass);
         $this->assertGit($git);
     }
@@ -142,14 +142,14 @@ class GitInfoCollectorTest extends \PHPUnit_Framework_TestCase
 
         $commit = $git->getHead();
 
-        $commitClass = 'Satooshi\Bundle\CoverallsV1Bundle\Entity\Git\Commit';
+        $commitClass = Commit::class;
         $this->assertTrue($commit instanceof $commitClass);
         $this->assertCommit($commit);
 
         $remotes = $git->getRemotes();
         $this->assertCount(1, $remotes);
 
-        $remoteClass = 'Satooshi\Bundle\CoverallsV1Bundle\Entity\Git\Remote';
+        $remoteClass = Remote::class;
         $this->assertTrue($remotes[0] instanceof $remoteClass);
         $this->assertRemote($remotes[0]);
     }

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommandTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommandTest.php
@@ -201,7 +201,7 @@ XML;
                 '--dry-run' => true,
                 '--config' => 'coveralls.yml',
                 '--env' => 'test',
-                '--coverage_clover' => 'nonexistense.xml',
+                '--coverage_clover' => 'nonexistent.xml',
             ]
         );
     }

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommandTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Command/CoverallsV1JobsCommandTest.php
@@ -195,7 +195,7 @@ XML;
         $_SERVER['TRAVIS'] = true;
         $_SERVER['TRAVIS_JOB_ID'] = 'command_test';
 
-        $actual = $commandTester->execute(
+        $commandTester->execute(
             [
                 'command' => $command->getName(),
                 '--dry-run' => true,

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Config/ConfiguratorTest.php
@@ -147,7 +147,7 @@ class ConfiguratorTest extends ProjectTestCase
 
         $path = realpath(__DIR__ . '/yaml/src_dir.yml');
 
-        $config = $this->object->load($path, $this->rootDir);
+        $this->object->load($path, $this->rootDir);
     }
 
     /**

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/CommitTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/CommitTest.php
@@ -198,12 +198,12 @@ class CommitTest extends \PHPUnit_Framework_TestCase
         $message = 'message';
 
         $this->object
-        ->setId($id)
-        ->setAuthorName($authorName)
-        ->setAuthorEmail($authorEmail)
-        ->setCommitterName($committerName)
-        ->setCommitterEmail($committerEmail)
-        ->setMessage($message);
+            ->setId($id)
+            ->setAuthorName($authorName)
+            ->setAuthorEmail($authorEmail)
+            ->setCommitterName($committerName)
+            ->setCommitterEmail($committerEmail)
+            ->setMessage($message);
 
         $expected = [
             'id' => $id,

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/GitTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/GitTest.php
@@ -24,8 +24,8 @@ class GitTest extends \PHPUnit_Framework_TestCase
         $remote = new Remote();
 
         return $remote
-        ->setName($name)
-        ->setUrl($url);
+            ->setName($name)
+            ->setUrl($url);
     }
 
     protected function createCommit($id = 'id', $authorName = 'author_name', $authorEmail = 'author_email', $committerName = 'committer_name', $committerEmail = 'committer_email', $message = 'message')
@@ -33,12 +33,12 @@ class GitTest extends \PHPUnit_Framework_TestCase
         $commit = new Commit();
 
         return $commit
-        ->setId($id)
-        ->setAuthorName($authorName)
-        ->setAuthorEmail($authorEmail)
-        ->setCommitterName($committerName)
-        ->setCommitterEmail($committerEmail)
-        ->setMessage($message);
+            ->setId($id)
+            ->setAuthorName($authorName)
+            ->setAuthorEmail($authorEmail)
+            ->setCommitterName($committerName)
+            ->setCommitterEmail($committerEmail)
+            ->setMessage($message);
     }
 
     // getBranch()

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/RemoteTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Entity/Git/RemoteTest.php
@@ -90,8 +90,8 @@ class RemoteTest extends \PHPUnit_Framework_TestCase
         $url = 'url';
 
         $this->object
-        ->setName($name)
-        ->setUrl($url);
+            ->setName($name)
+            ->setUrl($url);
 
         $expected = [
             'name' => $name,

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -183,10 +183,8 @@ class JobsRepositoryTest extends ProjectTestCase
     protected function createLoggerMock()
     {
         $logger = $this->prophesize(NullLogger::class);
-        $logger
-            ->info();
-        $logger
-            ->error();
+        $logger->info();
+        $logger->error();
 
         return $logger->reveal();
     }
@@ -235,8 +233,7 @@ class JobsRepositoryTest extends ProjectTestCase
     {
         $config = new Configuration();
 
-        return $config
-        ->addCloverXmlPath($this->cloverXmlPath);
+        return $config->addCloverXmlPath($this->cloverXmlPath);
     }
 
     // persist()

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Repository/JobsRepositoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Satooshi\Bundle\CoverallsV1Bundle\Repository;
 
+use Psr\Log\NullLogger;
+use Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs;
 use Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration;
 use Satooshi\Bundle\CoverallsV1Bundle\Entity\Exception\RequirementsNotSatisfiedException;
 use Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile;
@@ -141,7 +143,7 @@ class JobsRepositoryTest extends ProjectTestCase
 
     protected function createApiMockWithRequirementsNotSatisfiedException()
     {
-        $api = $this->prophesize('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs');
+        $api = $this->prophesize(Jobs::class);
         $this->setUpJobsApiWithCollectCloverXmlThrow($api, new RequirementsNotSatisfiedException());
         $this->setUpJobsApiWithGetJsonFileNotCalled($api);
         $this->setUpJobsApiWithCollectGitInfoNotCalled($api);
@@ -154,7 +156,7 @@ class JobsRepositoryTest extends ProjectTestCase
 
     protected function createApiMockWithException()
     {
-        $api = $this->prophesize('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs');
+        $api = $this->prophesize(Jobs::class);
         $this->setUpJobsApiWithCollectCloverXmlThrow($api, new \Exception('unexpected exception'));
         $this->setUpJobsApiWithGetJsonFileNotCalled($api);
         $this->setUpJobsApiWithCollectGitInfoNotCalled($api);
@@ -167,7 +169,7 @@ class JobsRepositoryTest extends ProjectTestCase
 
     protected function createApiMock($response, $statusCode = '', $uri = '/')
     {
-        $api = $this->prophesize('Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs');
+        $api = $this->prophesize(Jobs::class);
         $this->setUpJobsApiWithCollectCloverXmlCalled($api);
         $this->setUpJobsApiWithGetJsonFileCalled($api, $this->createJsonFile());
         $this->setUpJobsApiWithCollectGitInfoCalled($api);
@@ -180,7 +182,7 @@ class JobsRepositoryTest extends ProjectTestCase
 
     protected function createLoggerMock()
     {
-        $logger = $this->prophesize('\Psr\Log\NullLogger');
+        $logger = $this->prophesize(NullLogger::class);
         $logger
             ->info();
         $logger

--- a/tests/Satooshi/Component/Log/ConsoleLoggerTest.php
+++ b/tests/Satooshi/Component/Log/ConsoleLoggerTest.php
@@ -2,6 +2,8 @@
 
 namespace Satooshi\Component\Log;
 
+use Symfony\Component\Console\Output\StreamOutput;
+
 /**
  * @covers \Satooshi\Component\Log\ConsoleLogger
  *
@@ -11,7 +13,7 @@ class ConsoleLoggerTest extends \PHPUnit_Framework_TestCase
 {
     protected function createAdapterMockWith($message)
     {
-        $mock = $this->prophesize('\Symfony\Component\Console\Output\StreamOutput');
+        $mock = $this->prophesize(StreamOutput::class);
         $mock
             ->writeln($message)
             ->shouldBeCalled();

--- a/tests/Satooshi/Component/System/Git/GitCommandTest.php
+++ b/tests/Satooshi/Component/System/Git/GitCommandTest.php
@@ -12,7 +12,7 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
 {
     protected function createGitBranchesCommandMock($params)
     {
-        $adapter = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
+        $adapter = $this->prophesize(GitCommand::class);
         $adapter
             ->getBranches()
             ->willReturn($params)
@@ -23,7 +23,7 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
 
     protected function createGitHeadCommitCommandMock($params)
     {
-        $adapter = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
+        $adapter = $this->prophesize(GitCommand::class);
         $adapter
             ->getHeadCommit()
             ->willReturn($params)
@@ -34,7 +34,7 @@ class GitCommandTest extends \PHPUnit_Framework_TestCase
 
     protected function createGitRemotesCommandMock($params)
     {
-        $adapter = $this->prophesize('\Satooshi\Component\System\Git\GitCommand');
+        $adapter = $this->prophesize(GitCommand::class);
         $adapter
             ->getRemotes()
             ->willReturn($params)

--- a/tests/Satooshi/ProjectTestCase.php
+++ b/tests/Satooshi/ProjectTestCase.php
@@ -43,10 +43,8 @@ class ProjectTestCase extends \PHPUnit_Framework_TestCase
             }
         }
 
-        if ($logsDirUnwritable) {
-            if (file_exists($logsDir)) {
-                chmod($logsDir, 0577);
-            }
+        if ($logsDirUnwritable && file_exists($logsDir)) {
+            chmod($logsDir, 0577);
         }
 
         if ($jsonPathUnwritable) {


### PR DESCRIPTION
This PR

* [x] simplifies needlessly fully-qualified class names
* [x] moves an assignment of a default value out of an else branch
* [x] avoids usage of `isset()` where possible
* [x] removes useless `elseif` where we already return early
* [x] makes use of the `class` keyword
* [x] uses more appropriate assertions
* [x] removes unused imports
* [x] removes unused local variables
* [x] removes unused parameters
* [x] merges a condition with a parent condition
* [x] removes useless `return` statements
* [x] removes conditions and updates docblocks
* [x] uses `$this` in `@return` annotations when returning the same instance
* [x] uses more specific types for arguments in docblocks
* [x] fixes typos
* [x] removes a condition from a constructor and assigns default values instead