### PR TITLE
Fix: Do not hide default value in else branch

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
@@ -93,10 +93,10 @@ class CloverXmlCoverageCollector
             return;
         }
 
+        $filename = $absolutePath;
+
         if ($root !== DIRECTORY_SEPARATOR) {
             $filename = str_replace($root, '', $absolutePath);
-        } else {
-            $filename = $absolutePath;
         }
 
         return $this->collectCoverage($file, $absolutePath, $filename);


### PR DESCRIPTION
This PR

* [x] moves an assignment of a default value out of an `else` branch